### PR TITLE
update openssl version and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!resources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk -Uuv add --update --no-cache \
       less=487-r0 \
       libffi-dev=3.2.1-r3 \
       openssh-client=7.5_p1-r1 \
-      openssl=1.0.2k-r0
+      openssl=1.0.2m-r0
 
 ENV KUBECTL_VERSION=v1.8.1
 ENV HELM_VERSION=v2.6.2


### PR DESCRIPTION
The openssl update will fix this docker build error:
```
ERROR: unsatisfiable constraints:
  openssl-1.0.2m-r0:
    breaks: world[openssl=1.0.2k-r0]
```
The `.dockerignore` file will prevent a huge build context :)