### PR TITLE
execute on local minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,197 @@ Clone the git repository: https://github.com/giantswarm/e2e-harness.git
 
 ## Running e2e-harness
 
-TODO
+You can download a prebuilt binary from [here](https://github.com/giantswarm/e2e-harness/releases/) or,
+with a golang environment set up, build from source from the root of the project:
+```
+go build .
+```
+
+## How does e2e-harness work
+
+The goal of the project is making it easy to design and run e2e tests for kubernetes
+components. We have great tools for local development, like minikube, but the tests
+and results obtained using them are difficult to replicate on a CI environment.
+
+e2e-harness aims to abstract all the differences between local and CI environments,
+so that you can write the tests once and run them everywhere, making sure that if
+things work locally they will work too elsewhere.
+
+In order to achive that, e2e-harness has two operation modes: local and remote.
+The setup and teardown actions differ on each mode, but the test themselves (and
+the actions required to execute them) are the same.
+
+Regarding the test execution, all the actions are run on a container, so that the
+execution environment is always the same. We have put in place these binaries inside
+the container:
+
+* kubectl: k8s CLI client, allows us to run common setup actions or out of cluster
+tests (see below).
+* helm: at giantswarm most of the systems under tests are helm charts. We have
+installed the registry plugin too.
+* shipyard: it allows us to create and delete a remote minikube instance.
+
+The container image is published in quay registry `quay.io/giantswarm/e2e-harness:latest`
+and its Dockerfile can be found [here](https://github.com/giantswarm/e2e-harness/blob/master/Dockerfile).
+
+## Requirements
+
+The main requirement is having a recent docker version running on the host. Additionally,
+for each operation mode:
+
+* Local: [minikube](https://github.com/kubernetes/minikube) should be started with
+RBAC enabled before running e2e-harness:
+```
+$ minikube start --extra-config=apiserver.Authorization.Mode=RBAC
+```
+* Remote: as stated above e2e-harness uses [shipyard](https://giathub.com/giantswarm/shipyard)
+for setting up the remote cluster. shipyard currently only supports AWS as the
+backend engine, so the common environment variables for granting access to AWS
+are required too (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
+
+## Project initialization
+
+From the project root execute:
+
+```
+$ e2e-harness init
+```
+
+This will create a `e2e` directory, with the required files to start writing tests,
+see below. This is how the e2e directory looks like this:
+
+```
+├── Dockerfile
+├── main.go
+├── project.yaml
+└── tests
+    ├── example.go
+    └── runner.go
+```
+`project.yaml` defines how the end to end tests should be setup, which tests to
+run and how to tear them down. It includes the following fields:
+
+The rest of the files are an example of in cluster tests. These are executed as
+sonobuoy plugins. The example is written in go but you could use any langauge,
+see [the sonobuoy examples section](). These are the files included:
+
+* `Dockerfile`: Required, this is the image definition for the sonobuoy plugin that
+runs the in-cluster tests, see below for details.
+* `main.go`: Main file of the golang example, just calls the runner.
+* `tests/runner.go`: Part of the golang example, helper file that defines methods
+required for executing the tests.
+* `tests/example.go`: Part of the golang example, this is where the actual test is
+written. It must be registered in the runner during the `init` execution:
+```
+func init() {
+  Add(TestExample)
+}
+```
+The test functions need to fulfill this interface:
+```
+type Test func() (description string, err error)
+```
+being the `description` used in the sonobuoy test output.
+
+## e2e-harness lifecycle
+
+An e2e test execution involves three stages:
+
+* Setup: this is performed with the `setup` command.
+```
+$ e2e-harness setup --remote=[false|true]
+```
+It takes care of:
+  - Initializing the project, creating an interchange directory that will
+  be mounted on the test container for keeping state between command
+  executions.
+  - Prepare the connection to the test cluster: for remote executions this
+  will involve the creation of the cluster too. In local executions, the
+  connection settings to be able running minikube are made available in
+  the test container interchange directory.
+  - Run common set up steps: these will pu the test cluster in a common
+  initial state, basically installing tiller (helm's server side part) including
+  the required resources to make it work with RBAC enabled.
+  - Run specific setup steps: this are defined in the project file
+  `e2e/project.yaml` under the `setup` key. They are common steps (see their
+  description above) and can do things like installing the chart under test,
+  setting up required external resources, etc.
+* Run tests: invoking the `test` command:
+```
+$ e2e-harness test
+```
+First, the out of cluster tests are executed, if any, defined as
+regular `step` entries under the `outOfClusterTests` key. Then the in cluster tests,
+if they are enabled in `project.yaml`. You should enabled them only if they are
+present, if not enabling them causes an error, see above for a descrition about
+how to write this kind of tests.
+* Teardown: the teardown phase is executing using the `teardown` command.
+```
+$ e2e-harness teardown
+```
+It includes:
+  - Run specific teardown steps: this are defined in the project file
+  `e2e/project.yaml` under the `teardown` key. They are common steps (see their
+  description above) and can do things like removing the chart under test,
+  tearing down required external resources, etc.
+  - Run commomn tear down steps: these differ depending on the mode of operation,
+  for remote, ephemeral clusters they are just deleted, for local clusters tiller
+  and all the required RBAC setup is removed.
+
+## Writing tests
+
+e2e tests can be executed from agents either out of the test cluster or running
+inside that cluster:
+
+### Out of cluster tests
+
+Currently the out of cluster tests are executed as `step` elements in the
+`e2e/project.yaml` file, the elements in a `step` are:
+
+* `run`: string with the command to execute, multiline allowed.
+* `WaitFor`: optional element to check if the `run` command was successful, it has
+as nested items a `run` entry with the check command to be executed, a `pattern`
+entry with a regular expression pattern to be checked against the previous command
+output and a `timeout` with the number of miliseconds to keep executing the command
+and checking the output. An example step could be:
+```
+- run: kubectl create namespace giantswarm
+  waitFor:
+    run: kubectl get namespace
+    match: giantswarm\s*Active
+    timeout: 2000
+```
+In this case, the first `run` entry tries to create a namespace and the `waitFor` entry
+makes sure that the namespace is created and in Active state, with a deadline of 2 seconds.
+
+All the `run` and `pattern` elements expand environment variables of the form `$ENV_VAR`
+or `${ENV_VAR}`.
+
+As all the steps in the project file, these elements are run from the test container,
+so keep in mind that the binaries used must be available in it.
+
+### In cluster tests
+
+The in cluster tests execution are controlled by the `inClusterTests` entry in the project file:
+```
+inClusterTests:
+  enabled: true
+  env:
+  - name: ENV_VAR_1
+    value: VALUE_1
+  - name: ENV_VAR_2
+    value: VALUE_2
+```
+First of all, they must be enabled to be executed (set `enabled` field to `true`).
+You can also pass the plugin environment variables to control their execution through
+the `env` key.
+
+The in cluster tests are executed as [sonobuoy plugins](https://github.com/heptio/sonobuoy/blob/master/docs/plugins.md).
+e2e-harness takes care of installing all the required sonobuoy infrastructure,
+running the plugins with a container created from the image defined by `e2e/Dockerfile`
+grabbing the results and making them available in `.e2e-harness/workdir/plugin/e2e/results.xml`.
+The example project deployed with `e2e-harness init` shows how this can be done
+using golang, see the `Project initialilzation` section for details.
 
 ## Contact
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,23 +9,4 @@ var (
 		Use:   "e2e-harness",
 		Short: "Harness for custom kubernetes e2e testing",
 	}
-
-	gitCommit   string
-	projectName string
 )
-
-func SetGitCommit(value string) {
-	gitCommit = value
-}
-
-func GetGitCommit() string {
-	return gitCommit
-}
-
-func SetProjectName(value string) {
-	projectName = value
-}
-
-func GetProjectName() string {
-	return projectName
-}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -4,7 +4,6 @@ import (
 	"github.com/giantswarm/e2e-harness/pkg/cluster"
 	"github.com/giantswarm/e2e-harness/pkg/docker"
 	"github.com/giantswarm/e2e-harness/pkg/harness"
-	"github.com/giantswarm/e2e-harness/pkg/minikube"
 	"github.com/giantswarm/e2e-harness/pkg/patterns"
 	"github.com/giantswarm/e2e-harness/pkg/project"
 	"github.com/giantswarm/e2e-harness/pkg/tasks"
@@ -70,13 +69,6 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		c.Create,
 		p.CommonSetupSteps,
 		p.SetupSteps,
-	}
-
-	if !remoteCluster {
-		// build images for minikube
-		m := minikube.New(logger, d)
-
-		bundle = append(bundle, m.BuildImages)
 	}
 
 	return tasks.Run(bundle)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/e2e-harness/pkg/tasks"
 	"github.com/giantswarm/e2e-harness/pkg/wait"
 	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +61,8 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		RemoteCluster: remoteCluster,
 	}
 	h := harness.New(logger, hCfg)
-	c := cluster.New(logger, d, remoteCluster)
+	fs := afero.NewOsFs()
+	c := cluster.New(logger, fs, d, remoteCluster)
 
 	// tasks to run
 	bundle := []tasks.Task{

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/e2e-harness/pkg/cluster"
 	"github.com/giantswarm/e2e-harness/pkg/docker"
 	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/e2e-harness/pkg/minikube"
 	"github.com/giantswarm/e2e-harness/pkg/patterns"
 	"github.com/giantswarm/e2e-harness/pkg/project"
 	"github.com/giantswarm/e2e-harness/pkg/tasks"
@@ -25,7 +26,7 @@ var (
 func init() {
 	RootCmd.AddCommand(SetupCmd)
 
-	SetupCmd.Flags().BoolVar(&remoteCluster, "remote-cluster", true, "use remote cluster")
+	SetupCmd.Flags().BoolVar(&remoteCluster, "remote", true, "use remote cluster")
 	SetupCmd.Flags().StringVar(&name, "name", "e2e-harness", "CI execution identifier")
 }
 
@@ -35,15 +36,20 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	gitCommit := GetGitCommit()
-	projectName := GetProjectName()
+	projectTag := harness.GetProjectTag()
+	projectName := harness.GetProjectName()
+	// use latest tag for consumer projects (not dog-fooding e2e-harness)
+	e2eHarnessTag := projectTag
+	if projectName != "e2e-harness" {
+		e2eHarnessTag = "latest"
+	}
 
-	d := docker.New(logger, gitCommit)
+	d := docker.New(logger, e2eHarnessTag, remoteCluster)
 	pa := patterns.New(logger)
 	w := wait.New(logger, d, pa)
 	pCfg := &project.Config{
-		Name:      projectName,
-		GitCommit: gitCommit,
+		Name: projectName,
+		Tag:  projectTag,
 	}
 	pDeps := &project.Dependencies{
 		Logger: logger,
@@ -60,10 +66,17 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	// tasks to run
 	bundle := []tasks.Task{
 		h.Init,
+		h.WriteConfig,
 		c.Create,
 		p.CommonSetupSteps,
 		p.SetupSteps,
-		h.WriteConfig,
+	}
+
+	if !remoteCluster {
+		// build images for minikube
+		m := minikube.New(logger, d)
+
+		bundle = append(bundle, m.BuildImages)
 	}
 
 	return tasks.Run(bundle)

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSetupFlags(t *testing.T) {
-	remoteFlag := cmd.SetupCmd.Flags().Lookup("remote-cluster")
+	remoteFlag := cmd.SetupCmd.Flags().Lookup("remote")
 
 	t.Run("flag exists", func(t *testing.T) {
 		if remoteFlag == nil {

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -34,15 +34,21 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	imageTag := GetGitCommit()
-	projectName := GetProjectName()
+	projectTag := harness.GetProjectTag()
+	projectName := harness.GetProjectName()
 
-	d := docker.New(logger, imageTag)
+	// use latest tag for consumer projects (not dog-fooding e2e-harness)
+	e2eHarnessTag := projectTag
+	if projectName != "e2e-harness" {
+		e2eHarnessTag = "latest"
+	}
+
+	d := docker.New(logger, e2eHarnessTag, cfg.RemoteCluster)
 	pa := patterns.New(logger)
 	w := wait.New(logger, d, pa)
 	pCfg := &project.Config{
-		Name:      projectName,
-		GitCommit: gitCommit,
+		Name: projectName,
+		Tag:  projectTag,
 	}
 	pDeps := &project.Dependencies{
 		Logger: logger,
@@ -54,7 +60,12 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 
 	bundle := []tasks.Task{
 		p.TeardownSteps,
-		c.Delete,
+	}
+
+	if cfg.RemoteCluster {
+		bundle = append(bundle, c.Delete)
+	} else {
+		bundle = append(bundle, p.CommonTearDownSteps)
 	}
 
 	return tasks.Run(bundle)

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/e2e-harness/pkg/tasks"
 	"github.com/giantswarm/e2e-harness/pkg/wait"
 	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +57,8 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 		Wait:   w,
 	}
 	p := project.New(pDeps, pCfg)
-	c := cluster.New(logger, d, cfg.RemoteCluster)
+	fs := afero.NewOsFs()
+	c := cluster.New(logger, fs, d, cfg.RemoteCluster)
 
 	bundle := []tasks.Task{
 		p.TeardownSteps,

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/giantswarm/e2e-harness/pkg/docker"
 	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/e2e-harness/pkg/minikube"
 	"github.com/giantswarm/e2e-harness/pkg/patterns"
 	"github.com/giantswarm/e2e-harness/pkg/project"
 	"github.com/giantswarm/e2e-harness/pkg/results"
@@ -66,6 +67,13 @@ func runTest(cmd *cobra.Command, args []string) error {
 	bundle := []tasks.Task{
 		p.OutOfClusterTest,
 		p.InClusterTest,
+	}
+
+	if !cfg.RemoteCluster {
+		// build images for minikube
+		m := minikube.New(logger, d, projectTag)
+
+		bundle = append([]tasks.Task{m.BuildImages}, bundle...)
 	}
 
 	return tasks.Run(bundle)

--- a/e2e/project.yaml
+++ b/e2e/project.yaml
@@ -1,14 +1,18 @@
 version: 1
 setup:
-  - run: helm registry install quay.io/giantswarm/cert-operator-lab-chart -- --set imageTag=latest --set clusterName=my-cluster --wait
+  - run: helm registry install quay.io/giantswarm/cert-operator-lab-chart -- -n cert-operator-lab --set imageTag=latest --set clusterName=my-cluster --wait
     waitFor:
       run: kubectl get certificate
       match: No resources found\.
 
-  - run: helm registry install quay.io/giantswarm/cert-resource-lab-chart -- --set clusterName=my-cluster
+  - run: helm registry install quay.io/giantswarm/cert-resource-lab-chart -- -n cert-resource-lab --set clusterName=my-cluster
     waitFor:
       run: kubectl get secrets
       match: my-cluster-api\s*Opaque
 
 inClusterTest:
   enabled: true
+
+teardown:
+  - run: helm delete cert-resource-lab --purge
+  - run: helm delete cert-operator-lab --purge

--- a/e2e/project.yaml
+++ b/e2e/project.yaml
@@ -1,18 +1,4 @@
 version: 1
-setup:
-  - run: helm registry install quay.io/giantswarm/cert-operator-lab-chart -- -n cert-operator-lab --set imageTag=latest --set clusterName=my-cluster --wait
-    waitFor:
-      run: kubectl get certificate
-      match: No resources found\.
-
-  - run: helm registry install quay.io/giantswarm/cert-resource-lab-chart -- -n cert-resource-lab --set clusterName=my-cluster
-    waitFor:
-      run: kubectl get secrets
-      match: my-cluster-api\s*Opaque
 
 inClusterTest:
   enabled: true
-
-teardown:
-  - run: helm delete cert-resource-lab --purge
-  - run: helm delete cert-operator-lab --purge

--- a/main.go
+++ b/main.go
@@ -7,15 +7,7 @@ import (
 	"github.com/giantswarm/e2e-harness/cmd"
 )
 
-var (
-	gitCommit = "n/a"
-	name      = "e2e-harness"
-)
-
 func main() {
-	cmd.SetGitCommit(gitCommit)
-	cmd.SetProjectName(name)
-
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -3,5 +3,5 @@ package builder
 import "io"
 
 type Builder interface {
-	Build(out io.Writer, image, path string, env []string) error
+	Build(out io.Writer, image, path, tag string, env []string) error
 }

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,0 +1,7 @@
+package builder
+
+import "io"
+
+type Builder interface {
+	Build(out io.Writer, image, path string, env []string) error
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,8 +1,14 @@
 package cluster
 
 import (
+	"io"
+	"io/ioutil"
 	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
 
+	"github.com/giantswarm/e2e-harness/pkg/harness"
 	"github.com/giantswarm/e2e-harness/pkg/runner"
 	"github.com/giantswarm/micrologger"
 )
@@ -21,9 +27,27 @@ func New(logger micrologger.Logger, runner runner.Runner, remoteCluster bool) *C
 	}
 }
 
-// Create is a Task that creates a remote cluster.
+// Create is a Task that creates a remote cluster or, if we
+// are using a local one, puts in place the required files for
+// later access to it
 func (c *Cluster) Create() error {
-	return c.clusterAction("shipyard -action=start")
+	if c.remoteCluster {
+		return c.clusterAction("shipyard -action=start")
+	}
+	usr, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	err = c.copyMinikubeAssets(usr.HomeDir)
+	if err != nil {
+		return err
+	}
+	err = c.setupMinikubeConfig(usr.HomeDir)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Delete is a Task that gets rid of a remote cluster.
@@ -38,4 +62,116 @@ func (c *Cluster) clusterAction(command string) error {
 	err := c.runner.Run(os.Stdout, command)
 
 	return err
+}
+
+// copyMinikubeAssets copies all the files found in $HOME/.minikube to
+// the e2e-harness workdir (so that they will be accessible from the test
+// container)
+func (c *Cluster) copyMinikubeAssets(homeDir string) error {
+	c.logger.Log("info", "Making minikube assets accessible for the test container")
+
+	originDir := filepath.Join(homeDir, ".minikube")
+	baseDir, err := harness.BaseDir()
+	if err != nil {
+		return err
+	}
+	targetDir := filepath.Join(baseDir, "workdir", ".minikube")
+
+	// copy minikube directory
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		targetPath := strings.Replace(path, originDir, targetDir, 1)
+		if info.IsDir() {
+			return os.MkdirAll(targetPath, os.ModePerm)
+		}
+		return copyFile(path, targetPath)
+	}
+	err = filepath.Walk(originDir, walkFn)
+	if err != nil {
+		return err
+	}
+
+	// copy kube config (assumes the current context is minukube)
+	origKubeCfg := filepath.Join(homeDir, ".kube", "config")
+	targetKubeCfg, err := getMinikubeConfigPath()
+	if err != nil {
+		return err
+	}
+	targetKubeCfgDir := filepath.Dir(targetKubeCfg)
+	if err := os.MkdirAll(targetKubeCfgDir, os.ModePerm); err != nil {
+		return err
+	}
+	if err := copyFile(origKubeCfg, targetKubeCfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// setupMinikubeConfig replaces $HOME/.minukube in the k8s config
+// file (as seen by the container where all the commands are going to
+// be executed) by the path where the certificates can be found (again,
+// from the container point of view).
+func (c *Cluster) setupMinikubeConfig(homeDir string) error {
+	c.logger.Log("info", "Setting up minikube config for the test container")
+
+	// the default k8s config file references the required certificates
+	// to access minikube using $HOME/.minikube, we store this in originDir
+	originDir := filepath.Join(homeDir, ".minikube")
+
+	// path is the actual location of the k8s config file that will be used from the
+	// test container
+	path, err := getMinikubeConfigPath()
+	if err != nil {
+		return err
+	}
+	read, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// targetDir has the path where minikube certificates are stored as seen from
+	// the test container
+	targetDir := filepath.Join("/workdir", ".minikube")
+
+	newContents := strings.Replace(string(read), originDir, targetDir, -1)
+
+	err = ioutil.WriteFile(path, []byte(newContents), 0)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// getMinikubeConfigPath returns the actual path of the k8s config file that
+// will be used by the test container (path from the point of view of the
+// executing e2e-harness binary, not the test container).
+func getMinikubeConfigPath() (string, error) {
+	baseDir, err := harness.BaseDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(baseDir, "workdir", ".shipyard", "config")
+
+	return path, nil
+}
+
+func copyFile(orig, dst string) error {
+	in, err := os.Open(orig)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -178,5 +178,7 @@ func (c *Cluster) copyFile(orig, dst string) error {
 	if _, err = io.Copy(out, in); err != nil {
 		return microerror.Mask(err)
 	}
-	return out.Sync()
+	err = out.Sync()
+
+	return microerror.Mask(err)
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
 
@@ -53,7 +54,7 @@ func (d *Docker) Run(out io.Writer, command string) error {
 func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string) error {
 	dir, err := harness.BaseDir()
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	baseArgs := []string{

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -6,21 +6,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/giantswarm/e2e-harness/pkg/harness"
 	"github.com/giantswarm/micrologger"
 )
 
 type Docker struct {
-	logger   micrologger.Logger
-	imageTag string
+	logger        micrologger.Logger
+	imageTag      string
+	remoteCluster bool
 }
 
-func New(logger micrologger.Logger, imageTag string) *Docker {
+func New(logger micrologger.Logger, imageTag string, remoteCluster bool) *Docker {
 	return &Docker{
-		logger:   logger,
-		imageTag: imageTag,
+		logger:        logger,
+		imageTag:      imageTag,
+		remoteCluster: remoteCluster,
 	}
 }
 
@@ -28,23 +29,25 @@ func New(logger micrologger.Logger, imageTag string) *Docker {
 // setting up the port forwarding to the remote cluster, this command
 // is meant to be used after that cluster has been initialized
 func (d *Docker) RunPortForward(out io.Writer, command string) error {
-	args := append([]string{"quay.io/giantswarm/e2e-harness:" + d.imageTag}, "-c",
-		fmt.Sprintf("shipyard -action=forward-port && %s", command))
+	if !d.remoteCluster {
+		// no need to port forward in local clusters
+		return d.Run(out, command)
+	}
+
+	args := append([]string{
+		"quay.io/giantswarm/e2e-harness:" + d.imageTag},
+		"-c", fmt.Sprintf("shipyard -action=forward-port && %s", command))
 
 	return d.baseRun(out, "/bin/bash", args)
 }
 
 // Run executes a command in the e2e-harness container.
 func (d *Docker) Run(out io.Writer, command string) error {
-	var args []string
-	fields := strings.Fields(command)
-	if len(fields) > 1 {
-		args = fields[1:]
-	}
+	args := append([]string{
+		"quay.io/giantswarm/e2e-harness:" + d.imageTag},
+		"-c", command)
 
-	args = append([]string{"quay.io/giantswarm/e2e-harness:" + d.imageTag}, args...)
-
-	return d.baseRun(out, fields[0], args)
+	return d.baseRun(out, "/bin/bash", args)
 }
 
 func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string) error {
@@ -61,11 +64,32 @@ func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string) error 
 		"-e", "KUBECONFIG=/workdir/.shipyard/config",
 		"--entrypoint", entrypoint,
 	}
+	if !d.remoteCluster {
+		// accessing to local cluster requires using the host network
+		baseArgs = append(baseArgs, "--network", "host")
+	}
+
 	baseArgs = append(baseArgs, args...)
 
 	cmd := exec.Command("docker", baseArgs...)
 	cmd.Stdout = out
 	cmd.Stderr = out
+
+	return cmd.Run()
+}
+
+func (d *Docker) Build(out io.Writer, image, path string, env []string) error {
+	baseArgs := []string{
+		"build",
+		"--no-cache",
+		"-t", fmt.Sprintf("%s:%s", image, d.imageTag),
+		".",
+	}
+	cmd := exec.Command("docker", baseArgs...)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Dir = path
+	cmd.Env = env
 
 	return cmd.Run()
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -78,11 +78,11 @@ func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string) error 
 	return cmd.Run()
 }
 
-func (d *Docker) Build(out io.Writer, image, path string, env []string) error {
+func (d *Docker) Build(out io.Writer, image, path, tag string, env []string) error {
 	baseArgs := []string{
 		"build",
 		"--no-cache",
-		"-t", fmt.Sprintf("%s:%s", image, d.imageTag),
+		"-t", fmt.Sprintf("%s:%s", image, tag),
 		".",
 	}
 	cmd := exec.Command("docker", baseArgs...)

--- a/pkg/harness/harness.go
+++ b/pkg/harness/harness.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -34,22 +35,22 @@ func (h *Harness) Init() error {
 	h.logger.Log("info", "starting harness initialization")
 	baseDir, err := BaseDir()
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 	dir := filepath.Join(baseDir, "workdir")
 	err = os.MkdirAll(dir, 0777)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 	// circumvent umask settings, by assigning the right
 	// permissions to workdir and its parent
 	err = os.Chmod(baseDir, 0777)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 	err = os.Chmod(dir, 0777)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 	h.logger.Log("info", "finished harness initialization")
 	return nil
@@ -59,17 +60,17 @@ func (h *Harness) Init() error {
 func (h *Harness) WriteConfig() error {
 	dir, err := BaseDir()
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	content, err := yaml.Marshal(&h.cfg)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	err = ioutil.WriteFile(filepath.Join(dir, defaultConfigFile), []byte(content), 0644)
 
-	return err
+	return microerror.Mask(err)
 }
 
 // ReadConfig populates a Config struct data read
@@ -77,18 +78,18 @@ func (h *Harness) WriteConfig() error {
 func (h *Harness) ReadConfig() (Config, error) {
 	dir, err := BaseDir()
 	if err != nil {
-		return Config{}, err
+		return Config{}, microerror.Mask(err)
 	}
 
 	content, err := ioutil.ReadFile(filepath.Join(dir, defaultConfigFile))
 	if err != nil {
-		return Config{}, err
+		return Config{}, microerror.Mask(err)
 	}
 
 	c := &Config{}
 
 	if err := yaml.Unmarshal(content, c); err != nil {
-		return Config{}, err
+		return Config{}, microerror.Mask(err)
 	}
 
 	return *c, nil
@@ -97,7 +98,7 @@ func (h *Harness) ReadConfig() (Config, error) {
 func BaseDir() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return "", microerror.Mask(err)
 	}
 	return filepath.Join(dir, ".e2e-harness"), nil
 }

--- a/pkg/initializer/initializer.go
+++ b/pkg/initializer/initializer.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 )
@@ -165,7 +166,7 @@ func New(logger micrologger.Logger, fs afero.Fs, projectName string) *Initialize
 func (i *Initializer) CreateLayout() error {
 	wd, err := os.Getwd()
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	baseDir := filepath.Join(wd, "e2e")
@@ -176,7 +177,7 @@ func (i *Initializer) CreateLayout() error {
 	}
 
 	if err := i.fs.MkdirAll(baseDir, os.ModePerm); err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	afs := &afero.Afero{Fs: i.fs}
@@ -197,13 +198,13 @@ func (i *Initializer) CreateLayout() error {
 	}
 
 	if err := i.writeFiles(files, baseDir, afs); err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	testsDir := filepath.Join(baseDir, "tests")
 
 	if err := i.fs.MkdirAll(testsDir, os.ModePerm); err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	files = []fileDef{
@@ -218,7 +219,7 @@ func (i *Initializer) CreateLayout() error {
 	}
 
 	if err := i.writeFiles(files, testsDir, afs); err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 
 	return nil
@@ -229,7 +230,7 @@ func (i *Initializer) writeFiles(files []fileDef, baseDir string, afs *afero.Afe
 		path := filepath.Join(baseDir, f.name)
 
 		if err := afs.WriteFile(path, []byte(f.content), os.ModePerm); err != nil {
-			return err
+			return microerror.Mask(err)
 		}
 	}
 	return nil

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -1,0 +1,108 @@
+package minikube
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/giantswarm/e2e-harness/pkg/builder"
+	"github.com/giantswarm/e2e-harness/pkg/harness"
+	"github.com/giantswarm/micrologger"
+)
+
+type Minikube struct {
+	logger  micrologger.Logger
+	builder builder.Builder
+}
+
+func New(logger micrologger.Logger, builder builder.Builder) *Minikube {
+	return &Minikube{
+		logger:  logger,
+		builder: builder,
+	}
+}
+
+// BuildImages is a Task that build the required images for both the main
+// project and the e2e containers using the minikube docker environment.
+func (m *Minikube) BuildImages() error {
+	m.logger.Log("info", "Getting minikube docker environment")
+	env, err := m.getDockerEnv()
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	name := harness.GetProjectName()
+	image := fmt.Sprintf("quay.io/giantswarm/%s", name)
+	m.logger.Log("info", "Building image "+image)
+	if err := m.buildImage(name, dir, image, env); err != nil {
+		return err
+	}
+
+	e2eBinary := name + "-e2e"
+	e2eDir := filepath.Join(dir, "e2e")
+	e2eImage := fmt.Sprintf("quay.io/giantswarm/%s-e2e", name)
+	m.logger.Log("info", "Building image "+e2eImage)
+	if err := m.buildImage(e2eBinary, e2eDir, e2eImage, env); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Minikube) getDockerEnv() ([]string, error) {
+	cmd := exec.Command("minikube", "docker-env")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return []string{}, err
+	}
+	if err := cmd.Start(); err != nil {
+		return []string{}, err
+	}
+
+	var env []string
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "export") {
+			parts := strings.Fields(scanner.Text())
+			entry := strings.Replace(parts[1], `"`, "", -1)
+			env = append(env, entry)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return env, err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return []string{}, err
+	}
+
+	return env, nil
+}
+
+func compile(binaryName, path string) error {
+	cmd := exec.Command("go", "build", "-o", binaryName, ".")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Dir = path
+
+	return cmd.Run()
+}
+
+func (m *Minikube) buildImage(binaryName, path, imageName string, env []string) error {
+	if err := compile(binaryName, path); err != nil {
+		fmt.Println("error compiling binary", binaryName)
+		return err
+	}
+
+	if err := m.builder.Build(ioutil.Discard, imageName, path, env); err != nil {
+		fmt.Println("error building image", imageName)
+		return err
+	}
+	return nil
+}

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -15,14 +15,16 @@ import (
 )
 
 type Minikube struct {
-	logger  micrologger.Logger
-	builder builder.Builder
+	logger   micrologger.Logger
+	builder  builder.Builder
+	imageTag string
 }
 
-func New(logger micrologger.Logger, builder builder.Builder) *Minikube {
+func New(logger micrologger.Logger, builder builder.Builder, tag string) *Minikube {
 	return &Minikube{
-		logger:  logger,
-		builder: builder,
+		logger:   logger,
+		builder:  builder,
+		imageTag: tag,
 	}
 }
 
@@ -100,7 +102,7 @@ func (m *Minikube) buildImage(binaryName, path, imageName string, env []string) 
 		return err
 	}
 
-	if err := m.builder.Build(ioutil.Discard, imageName, path, env); err != nil {
+	if err := m.builder.Build(ioutil.Discard, imageName, path, m.imageTag, env); err != nil {
 		fmt.Println("error building image", imageName)
 		return err
 	}

--- a/pkg/patterns/patterns.go
+++ b/pkg/patterns/patterns.go
@@ -31,7 +31,6 @@ func (pa *Patterns) Find(input io.Reader, pattern string) (bool, error) {
 
 	scanner := bufio.NewScanner(input)
 	for scanner.Scan() {
-		pa.logger.Log("debug", "line to match: "+scanner.Text())
 		if r.MatchString(scanner.Text()) {
 			return true, nil
 		}

--- a/pkg/patterns/patterns.go
+++ b/pkg/patterns/patterns.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"regexp"
 
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
 
@@ -26,7 +27,7 @@ func New(logger micrologger.Logger) *Patterns {
 func (pa *Patterns) Find(input io.Reader, pattern string) (bool, error) {
 	r, err := regexp.Compile(pattern)
 	if err != nil {
-		return false, err
+		return false, microerror.Mask(err)
 	}
 
 	scanner := bufio.NewScanner(input)
@@ -36,7 +37,7 @@ func (pa *Patterns) Find(input io.Reader, pattern string) (bool, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return false, err
+		return false, microerror.Mask(err)
 	}
 	return false, nil
 }

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -1,5 +1,7 @@
 package tasks
 
+import "github.com/giantswarm/microerror"
+
 // Task represent a generic step in a pipeline.
 type Task func() error
 
@@ -8,7 +10,7 @@ func Run(tasks []Task) error {
 	for _, task := range tasks {
 		err = task()
 		if err != nil {
-			return err
+			return microerror.Mask(err)
 		}
 	}
 	return nil

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/giantswarm/e2e-harness/pkg/patterns"
 	"github.com/giantswarm/e2e-harness/pkg/runner"
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
 
@@ -66,7 +67,7 @@ func (w *Wait) For(md *MatchDef) error {
 			}()
 			ok, err := w.matcher.Find(re, md.Match)
 			if err != nil {
-				return err
+				return microerror.Mask(err)
 			} else if ok {
 				return nil
 			}

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -49,6 +49,7 @@ func (w *Wait) For(md *MatchDef) error {
 	timeout := time.After(md.Deadline * time.Millisecond)
 	tick := time.Tick(md.Step * time.Millisecond)
 
+	w.logger.Log("debug", fmt.Sprintf("waiting for pattern %q in %q output", md.Match, md.Run))
 	for {
 		select {
 		case <-timeout:
@@ -63,15 +64,12 @@ func (w *Wait) For(md *MatchDef) error {
 				defer wr.Close()
 				w.runner.RunPortForward(wr, md.Run)
 			}()
-			w.logger.Log("debug", "checking pattern "+md.Match)
 			ok, err := w.matcher.Find(re, md.Match)
 			if err != nil {
 				return err
 			} else if ok {
-				w.logger.Log("debug", "match found")
 				return nil
 			}
-			w.logger.Log("debug", "match not found, retrying")
 		}
 	}
 }


### PR DESCRIPTION
These changes will allow execution of tests using a local minikube. It should be started with RBAC enabled before setting up the e2e environment:
```
$ minikube start --extra-config=apiserver.Authorization.Mode=RBAC
```
Then, the common workflow would be:
```
$ e2e-harness init # only if ./e2e doesn't exists
[ hack on ./e2e directory... ]
$ e2e-harness setup --remote=false
$ e2e-harness test # repeat as needed
$ e2e-harness teardown
```

@kopiczko there's another branch in progress for running the out of cluster tests connecting directly to the test cluster, defined as golang tests that receive a configured k8s client but removing sonobuoy (used for in-cluster) and the project.yaml step definitions from the equation as you proposed. The same tests can be used for both local development and CI, will come next.