### PR TITLE
specify container dns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk -Uuv add --update --no-cache \
       less=487-r0 \
       libffi-dev=3.2.1-r3 \
       openssh-client=7.5_p1-r1 \
-      openssl=1.0.2m-r0
+      openssl=1.0.2n-r0
 
 ENV KUBECTL_VERSION=v1.8.1
 ENV HELM_VERSION=v2.6.2

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -67,6 +67,7 @@ func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string, env ..
 		"-e", fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", os.Getenv("AWS_ACCESS_KEY_ID")),
 		"-e", fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", os.Getenv("AWS_SECRET_ACCESS_KEY")),
 		"-e", "KUBECONFIG=" + harness.DefaultKubeConfig,
+		"--dns", "8.8.8.8",
 		"--entrypoint", entrypoint,
 	}
 


### PR DESCRIPTION
This will prevent name resolution errors on CircleCI:
```
2017/12/21 14:26:33 waiting for k8s API up: Get https://api.ci-awsop-6d7afef.gauss.eu-central-1.aws.gigantic.io/api/v1/namespaces/default/services/kubernetes: dial tcp: lookup api.ci-awsop-6d7afef.gauss.eu-central-1.aws.gigantic.io on 169.254.169.254:53: no such host
```