### PR TITLE
Setup localkube

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,27 +24,30 @@ jobs:
             ./architect deploy
           fi
 
-  e2eSetup:
+  e2eLocalTest:
+    working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/e2e-harness
     machine: true
+    environment:
+      MINIKUBE_VERSION: v0.25.0
     steps:
     - checkout
 
     - attach_workspace:
         at: .
 
-    - run: ./e2e-harness setup --name=ci-e2e-harness-${CIRCLE_SHA1:0:7}
+    - run: ./e2e-harness localkube
+
+    - run: ./e2e-harness setup --remote=false
+
+    - run: ./e2e-harness test
 
     - run:
-        name: Cleanup on failure
+        name: Finish with cleanup, no matter if the test succeeded or not
         command: ./e2e-harness teardown
-        when: on_fail
+        when: always
 
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ./.e2e-harness
-
-  e2eTestExecution:
+  e2eRemoteTest:
+    working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/e2e-harness
     machine: true
     steps:
     - checkout
@@ -52,12 +55,7 @@ jobs:
     - attach_workspace:
         at: .
 
-    - run:
-        name: additional setup required for dogfooding e2e-harness
-        command: |
-          mkdir -p /home/circleci/.go_workspace/src/github.com/giantswarm/e2e-harness
-          cp -ar ./pkg/ /home/circleci/.go_workspace/src/github.com/giantswarm/e2e-harness
-          cp -ar vendor/* /home/circleci/.go_workspace/src/
+    - run: ./e2e-harness setup
 
     - run: ./e2e-harness test
 
@@ -71,9 +69,9 @@ workflows:
   build_e2e:
     jobs:
       - build
-      - e2eSetup:
+      - e2eLocalTest:
           requires:
           - build
-      - e2eTestExecution:
+      - e2eRemoteTest:
           requires:
-          - e2eSetup
+          - build

--- a/cmd/localkube.go
+++ b/cmd/localkube.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/e2e-harness/pkg/localkube"
+	"github.com/giantswarm/e2e-harness/pkg/tasks"
+)
+
+var (
+	LocalkubeCmd = &cobra.Command{
+		Use:   "localkube",
+		Short: "setup localkube",
+		RunE:  runLocalkube,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(LocalkubeCmd)
+}
+
+func runLocalkube(cmd *cobra.Command, args []string) error {
+	l := localkube.New()
+
+	// tasks to run
+	bundle := []tasks.Task{
+		l.SetUp,
+	}
+
+	return tasks.Run(bundle)
+}

--- a/pkg/localkube/localkube.go
+++ b/pkg/localkube/localkube.go
@@ -1,0 +1,80 @@
+package localkube
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	minikubeDownloadURL = "https://github.com/kubernetes/minikube/releases/download/$MINIKUBE_VERSION/minikube-linux-amd64"
+)
+
+type Localkube struct {
+}
+
+func New() *Localkube {
+	return &Localkube{}
+}
+
+func (l *Localkube) SetUp() error {
+	// download minikube binary.
+	if err := downloadFromURL(minikubeDownloadURL); err != nil {
+		return microerror.Mask(err)
+	}
+
+	commands := []string{
+		"chmod a+x ./minikube-linux-amd64",
+		"sudo ./minikube-linux-amd64 start --vm-driver=none",
+		"sudo chown -R $USER $HOME/.kube",
+		"sudo chgrp -R $USER $HOME/.kube",
+		"sudo chown -R $USER $HOME/.minikube",
+		"sudo chgrp -R $USER $HOME/.minikube",
+		"./minikube-linux-amd64 update-context",
+	}
+	for _, command := range commands {
+		if err := l.runCmd(command); err != nil {
+			return microerror.Mask(err)
+		}
+	}
+	return nil
+}
+
+func (l *Localkube) runCmd(command string) error {
+	command = os.ExpandEnv(command)
+	items := strings.Fields(command)
+	cmd := exec.Command(items[0], items[1:]...)
+	cmd.Stderr = os.Stdout
+	cmd.Stdout = os.Stdout
+
+	return cmd.Run()
+}
+
+func downloadFromURL(url string) error {
+	url = os.ExpandEnv(url)
+
+	tokens := strings.Split(url, "/")
+	fileName := tokens[len(tokens)-1]
+	output, err := os.Create(fileName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer output.Close()
+
+	response, err := http.Get(url)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer response.Body.Close()
+
+	_, err = io.Copy(output, response.Body)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Allows to setup localkube (minikube with `--vm-driver=none`) on circleCI machines. This way we don't need to spin up a remote minikube for each e2e execution and the setup is slightly quicker (~30sec see https://circleci.com/workflow-run/7c72def2-b09f-49bc-bc30-f07a5334ab46 for example).