### PR TITLE
Only build binaries if they are not already created

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -108,8 +108,8 @@ func executebleExists(path string) bool {
 	// 0111 octal represents a mode with the executable bit set
 	// for user, group and others. Performing a bitwise and with
 	// the mode of the file would only result in 0 if all these
-	// bit flags are 0, so if the result of the and is different
-	// from 0 we can assume that the file is executable.
+	// bit flags are 0, so if the result is different from 0 we
+	// can assume that the file is executable.
 	isExecutable := fi.Mode()&os.FileMode(0111) != 0
 
 	return isExecutable

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -58,6 +58,8 @@ func (c *Compiler) CompileTests() error {
 	return nil
 }
 
+// compileMain compiles a go binary in the given path giving it the provided
+// name. If the binary already exists and is executable the build is skipped
 func (c *Compiler) compileMain(binaryName, path string) error {
 	// do not build if binary is already there
 	binPath := filepath.Join(path, binaryName)
@@ -73,6 +75,9 @@ func (c *Compiler) compileMain(binaryName, path string) error {
 	return cmd.Run()
 }
 
+// compileTests compiles a go test binary in the given path giving it the
+// provided name. If the binary already exists and is executable the build
+// is skipped
 func (c *Compiler) compileTests(binaryName, path string) error {
 	// do not build if binary is already there
 	binPath := filepath.Join(path, binaryName)

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -64,7 +64,7 @@ func (c *Compiler) compileMain(binaryName, path string) error {
 	// do not build if binary is already there
 	binPath := filepath.Join(path, binaryName)
 	if executebleExists(binPath) {
-		c.logger.Log("info", "main binary exists, not building")
+		c.logger.Log("function", "compileMain", "level", "info", "message", "main binary exists, not building")
 		return nil
 	}
 
@@ -82,7 +82,7 @@ func (c *Compiler) compileTests(binaryName, path string) error {
 	// do not build if binary is already there
 	binPath := filepath.Join(path, binaryName)
 	if executebleExists(binPath) {
-		c.logger.Log("info", "test binary exists, not building")
+		c.logger.Log("function", "compileTests", "level", "info", "message", "test binary exists, not building")
 		return nil
 	}
 

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -100,6 +100,11 @@ func executebleExists(path string) bool {
 		return false
 	}
 
+	// 0111 octal represents a mode with the executable bit set
+	// for user, group and others. Performing a bitwise and with
+	// the mode of the file would only result in 0 if all these
+	// bit flags are 0, so if the result of the and is different
+	// from 0 wee can assume that the file is executable.
 	isExecutable := fi.Mode()&os.FileMode(0111) != 0
 
 	return isExecutable

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -109,7 +109,7 @@ func executebleExists(path string) bool {
 	// for user, group and others. Performing a bitwise and with
 	// the mode of the file would only result in 0 if all these
 	// bit flags are 0, so if the result of the and is different
-	// from 0 wee can assume that the file is executable.
+	// from 0 we can assume that the file is executable.
 	isExecutable := fi.Mode()&os.FileMode(0111) != 0
 
 	return isExecutable


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2712 and https://github.com/giantswarm/giantswarm/issues/2678

With these changes we will be able to reuse the binary created in the initial build job, improving the e2e total build time.