### PR TITLE
aligns the log entry for guest cluster main stack deletion

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -343,7 +343,7 @@ func (f *Framework) DeleteGuestCluster() error {
 		return microerror.Mask(err)
 	}
 
-	logEntry := "deleting AWS Host Post-Guest CloudFormation stack: deleted"
+	logEntry := "deleted the guest cluster main stack"
 
 	return f.WaitForPodLog("giantswarm", logEntry, operatorPodName)
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2758. See also https://github.com/giantswarm/aws-operator/pull/832. 