### PR TITLE
increases wait time to 30 minutes again to prevent timeout errors

### DIFF
--- a/pkg/framework/wait.go
+++ b/pkg/framework/wait.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultTimeout = 900
+	defaultTimeout = 1800
 )
 
 func waitFor(f func() error) error {


### PR DESCRIPTION
This is to increase probability of e2e tests to succeed in combination with cloud providers plus being able to investigate on the machines in case things take way too long. I hope to find some things in the long run we can maybe improve or fix in our setup to make it more stable and reliable. 