### PR TITLE
Retry setup operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk -Uuv add --update --no-cache \
       less=487-r0 \
       libffi-dev=3.2.1-r3 \
       openssh-client=7.5_p1-r2 \
-      openssl=1.0.2n-r0
+      openssl=1.0.2o-r0
 
 ENV KUBECTL_VERSION=v1.8.1
 ENV HELM_VERSION=v2.6.2

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -101,7 +101,7 @@ func (p *Project) CommonSetupSteps() error {
 
 	newNotify := func(operationName string) func(error, time.Duration) {
 		return func(err error, delay time.Duration) {
-			p.logger.Log(fmt.Sprintf("%q failed, retrying with delay %.0fm%.0fs: '%#v'", operationName, delay.Minutes(), delay.Seconds(), err))
+			p.logger.Log(fmt.Sprintf("%q failed, retrying with delay %s: '%#v'", operationName, delay, err))
 		}
 	}
 	for _, s := range steps {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2571

This can prevent transient errors during setup by retrying the failing tasks.