### PR TITLE
Bump default minikube version

### DIFF
--- a/cmd/localkube.go
+++ b/cmd/localkube.go
@@ -23,7 +23,7 @@ var (
 func init() {
 	RootCmd.AddCommand(LocalkubeCmd)
 
-	SetupCmd.Flags().StringVar(&minikubeVersion, "minikube-version", "v0.25.0", "Minikube version to use.")
+	SetupCmd.Flags().StringVar(&minikubeVersion, "minikube-version", "v0.25.2", "Minikube version to use.")
 }
 
 func runLocalkube(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Sets it to latest `v.0.25.2`, which gives k8s `1.9.4`.