### PR TITLE
Expose InstallOperator

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -115,7 +115,7 @@ func (h *Host) DeleteGuestCluster() error {
 }
 
 func (h *Host) InstallStableOperator(name, cr, values string) error {
-	err := h.installOperator(name, cr, values, ":stable")
+	err := h.InstallOperator(name, cr, values, ":stable")
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -123,14 +123,14 @@ func (h *Host) InstallStableOperator(name, cr, values string) error {
 }
 
 func (h *Host) InstallBranchOperator(name, cr, values string) error {
-	err := h.installOperator(name, cr, values, "@1.0.0-${CIRCLE_SHA1}")
+	err := h.InstallOperator(name, cr, values, "@1.0.0-${CIRCLE_SHA1}")
 	if err != nil {
 		return microerror.Mask(err)
 	}
 	return nil
 }
 
-func (h *Host) installOperator(name, cr, values, version string) error {
+func (h *Host) InstallOperator(name, cr, values, version string) error {
 	chartValuesEnv := os.ExpandEnv(values)
 
 	tmpfile, err := ioutil.TempFile("", name+"-values")


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

chart-operator doesn't follow the version pattern `1.0.0-${CIRCLE_SHA1}` we have in other operators, because it's going to be self-installed it needs to follow the new pattern with actual semantic versions (like `3.1.7`) and stability-related channels. Because of that the currently exposed methods for installing operators (from the `stable` channel or from `1.0.0-${CIRCLE_SHA1}` version) are not enough, we need to specify exactly the channel to pull the chart from (in PRs this will be `CIRCLE_SHA1`). This can be done exposing the base method `installOperator`.