### PR TITLE
provide generic method to install resource

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -162,6 +162,32 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	return nil
 }
 
+func (h *Host) InstallResource(name, values string) error {
+	chartValuesEnv := os.ExpandEnv(values)
+
+	tmpfile, err := ioutil.TempFile("", name+"-values")
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(chartValuesEnv)); err != nil {
+		return microerror.Mask(err)
+	}
+
+	cmd := fmt.Sprintf("registry install quay.io/giantswarm/%[1]s -- -n %[1]s --values %[2]s", name, tmpfile.Name())
+	operation := func() error {
+		return HelmCmd(cmd)
+	}
+	notify := newNotify(name + " install")
+	err = backoff.RetryNotify(operation, h.backoff, notify)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
 func (h *Host) InstallCertResource() error {
 	operation := func() error {
 		return HelmCmd("registry install quay.io/giantswarm/cert-resource-lab-chart:stable -- -n cert-resource-lab --set commonDomain=${COMMON_DOMAIN_GUEST} --set clusterName=${CLUSTER_NAME}")


### PR DESCRIPTION
As mentioned in giantswarm/azure-operator#162 (comment)
I implemented this method toward having a generic way to install resource.

But I am not sure how to handle the different wait cases here.
One solution would be to pass the wait function as an argument and if present call `waitFor(argFunction())`
It would then also be nice to export `h.secret` and `h.runningPod`.