### PR TITLE
exposes initialized k8s clients for guest and host frameworks

### DIFF
--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -22,12 +22,14 @@ const (
 )
 
 type Guest struct {
-	k8sClient kubernetes.Interface
+	k8sClient  kubernetes.Interface
+	restConfig *rest.Config
 }
 
 func NewGuest() (*Guest, error) {
 	g := &Guest{
-		k8sClient: nil,
+		k8sClient:  nil,
+		restConfig: nil,
 	}
 
 	return g, nil
@@ -38,6 +40,13 @@ func NewGuest() (*Guest, error) {
 // successfully.
 func (g *Guest) K8sClient() kubernetes.Interface {
 	return g.k8sClient
+}
+
+// RestConfig returns the guest cluster framework's rest config. The config
+// being returned is properly configured ones Guest.Setup() got executed
+// successfully.
+func (g *Guest) RestConfig() *rest.Config {
+	return g.restConfig
 }
 
 // Setup provides a separate initialization step because of the nature of the
@@ -61,6 +70,7 @@ func (g *Guest) Setup() error {
 	}
 
 	var guestK8sClient kubernetes.Interface
+	var guestRestConfig *rest.Config
 	{
 		n := os.ExpandEnv("${CLUSTER_NAME}-api")
 		s, err := hostK8sClient.CoreV1().Secrets("default").Get(n, metav1.GetOptions{})
@@ -68,7 +78,7 @@ func (g *Guest) Setup() error {
 			return microerror.Mask(err)
 		}
 
-		c := &rest.Config{
+		guestRestConfig := &rest.Config{
 			Host: os.ExpandEnv("https://api.${CLUSTER_NAME}.${COMMON_DOMAIN_GUEST}"),
 			TLSClientConfig: rest.TLSClientConfig{
 				CAData:   s.Data["ca"],
@@ -77,13 +87,14 @@ func (g *Guest) Setup() error {
 			},
 		}
 
-		guestK8sClient, err = kubernetes.NewForConfig(c)
+		guestK8sClient, err = kubernetes.NewForConfig(guestRestConfig)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	}
 
 	g.k8sClient = guestK8sClient
+	g.restConfig = guestRestConfig
 
 	err = g.WaitForGuestReady()
 	if err != nil {

--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -33,6 +33,13 @@ func NewGuest() (*Guest, error) {
 	return g, nil
 }
 
+// K8sClient returns the guest cluster framework's Kubernetes client. The client
+// being returned is properly configured ones Guest.Setup() got executed
+// successfully.
+func (g *Guest) K8sClient() kubernetes.Interface {
+	return g.k8sClient
+}
+
 // Setup provides a separate initialization step because of the nature of the
 // host/guest cluster design. We have to setup things in different stages.
 // Constructing the frameworks can be done right away but setting them up can

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	giantclientset "github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +37,7 @@ type HostConfig struct {
 
 type Host struct {
 	backoff   *backoff.ExponentialBackOff
-	g8sClient *giantclientset.Clientset
+	g8sClient *versioned.Clientset
 	k8sClient kubernetes.Interface
 }
 
@@ -51,7 +51,7 @@ func NewHost(c HostConfig) (*Host, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	g8sClient, err := giantclientset.NewForConfig(config)
+	g8sClient, err := versioned.NewForConfig(config)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -172,6 +172,11 @@ func (h *Host) InstallCertResource() error {
 	secretName := fmt.Sprintf("%s-api", os.Getenv("CLUSTER_NAME"))
 	log.Printf("waiting for secret %v\n", secretName)
 	return waitFor(h.secret("default", secretName))
+}
+
+// K8sClient returns the host cluster framework's Kubernetes client.
+func (h *Host) K8sClient() kubernetes.Interface {
+	return h.k8sClient
 }
 
 func (h *Host) PodName(namespace, labelSelector string) (string, error) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2737. The idea is here to let us use the k8s clients freely during development. Once we notice functionality becomes common ground we can move it to the framework but for prototyping and playing around it is super useful to have the clients setup and available in integration tests. 