### PR TITLE
makes common backoff creation publicly available

### DIFF
--- a/pkg/framework/backoff.go
+++ b/pkg/framework/backoff.go
@@ -16,7 +16,7 @@ const (
 	ShortMaxInterval = 5 * time.Second
 )
 
-func newExponentialBackoff(maxWait, maxInterval time.Duration) *backoff.ExponentialBackOff {
+func NewExponentialBackoff(maxWait, maxInterval time.Duration) *backoff.ExponentialBackOff {
 	b := &backoff.ExponentialBackOff{
 		InitialInterval:     backoff.DefaultInitialInterval,
 		RandomizationFactor: backoff.DefaultRandomizationFactor,

--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -118,7 +118,7 @@ func (g *Guest) WaitForAPIDown() error {
 
 		return microerror.Maskf(waitError, "k8s API is still up")
 	}
-	b := newExponentialBackoff(ShortMaxWait, ShortMaxInterval)
+	b := NewExponentialBackoff(ShortMaxWait, ShortMaxInterval)
 	n := func(err error, delay time.Duration) {
 		log.Println("level", "debug", "message", err.Error())
 	}
@@ -144,7 +144,7 @@ func (g *Guest) WaitForAPIUp() error {
 
 		return nil
 	}
-	b := newExponentialBackoff(LongMaxWait, LongMaxInterval)
+	b := NewExponentialBackoff(LongMaxWait, LongMaxInterval)
 	n := func(err error, delay time.Duration) {
 		log.Println("level", "debug", "message", err.Error())
 	}
@@ -198,7 +198,7 @@ func (g *Guest) WaitForNodesUp(numberOfNodes int) error {
 
 		return nil
 	}
-	b := newExponentialBackoff(LongMaxWait, LongMaxInterval)
+	b := NewExponentialBackoff(LongMaxWait, LongMaxInterval)
 	n := func(err error, delay time.Duration) {
 		log.Println("level", "debug", "message", err.Error())
 	}


### PR DESCRIPTION
This is to be able to reuse the common backoff functionality in our operators where necessary. 