### PR TITLE
remove version from name

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -132,11 +132,11 @@ func (h *Host) InstallBranchOperator(name, cr, values string) error {
 }
 
 func (h *Host) InstallOperator(name, cr, values, version string) error {
-	chartName := fmt.Sprintf("%s-chart%s", name, version)
-	return h.InstallResource(chartName, values, h.crd(cr))
+	chartName := fmt.Sprintf("%s-chart", name)
+	return h.InstallResource(chartName, version, values, h.crd(cr))
 }
 
-func (h *Host) InstallResource(name, values string, conditions ...func() error) error {
+func (h *Host) InstallResource(name, version, values string, conditions ...func() error) error {
 	chartValuesEnv := os.ExpandEnv(values)
 
 	tmpfile, err := ioutil.TempFile("", name+"-values")
@@ -149,7 +149,7 @@ func (h *Host) InstallResource(name, values string, conditions ...func() error) 
 		return microerror.Mask(err)
 	}
 
-	installCmd := fmt.Sprintf("registry install quay.io/giantswarm/%[1]s -- -n %[1]s --values %[2]s", name, tmpfile.Name())
+	installCmd := fmt.Sprintf("registry install quay.io/giantswarm/%[1]s%[2]s -- -n %[1]s --values %[3]s", name, version, tmpfile.Name())
 	deleteCmd := fmt.Sprintf("delete --purge %s", name)
 	operation := func() error {
 		// NOTE we ignore errors here because we cannot get really useful error

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -132,11 +132,10 @@ func (h *Host) InstallBranchOperator(name, cr, values string) error {
 }
 
 func (h *Host) InstallOperator(name, cr, values, version string) error {
-	chartName := fmt.Sprintf("%s-chart", name)
-	return h.InstallResource(chartName, version, values, h.crd(cr))
+	return h.InstallResource(name, values, version, h.crd(cr))
 }
 
-func (h *Host) InstallResource(name, version, values string, conditions ...func() error) error {
+func (h *Host) InstallResource(name, values, version string, conditions ...func() error) error {
 	chartValuesEnv := os.ExpandEnv(values)
 
 	tmpfile, err := ioutil.TempFile("", name+"-values")
@@ -149,7 +148,7 @@ func (h *Host) InstallResource(name, version, values string, conditions ...func(
 		return microerror.Mask(err)
 	}
 
-	installCmd := fmt.Sprintf("registry install quay.io/giantswarm/%[1]s%[2]s -- -n %[1]s --values %[3]s", name, version, tmpfile.Name())
+	installCmd := fmt.Sprintf("registry install quay.io/giantswarm/%[1]s-chart%[2]s -- -n %[1]s --values %[3]s", name, version, tmpfile.Name())
 	deleteCmd := fmt.Sprintf("delete --purge %s", name)
 	operation := func() error {
 		// NOTE we ignore errors here because we cannot get really useful error


### PR DESCRIPTION
Going back to having version separate from component name will prevent errors like:

```
2018/04/18 15:18:37 Running command "helm registry install quay.io/giantswarm/cluster-operator-chart@1.0.0-${CIRCLE_SHA1} -- -n cluster-operator-chart@1.0.0-${CIRCLE_SHA1} --values /tmp/cluster-operator-chart@1.0.0-${CIRCLE_SHA1}-values808558547"
usage: appr [-h]
            {pull,run-server,show,inspect,list,delete-package,helm,version,logout,deploy,plugins,push,login,config,channel,jsonnet}
            ...
appr: error: 
message: 'Error: open /tmp/cluster-operator-chart@1.0.0-afb7ce1a4652a63aa55316b942c2715772e52492-values808558547: no such file or directory
```