### PR TITLE
enable network management from container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN apk -Uuv add --update --no-cache \
       less=520-r0 \
       libffi-dev=3.2.1-r4 \
       openssh-client=7.5_p1-r8 \
-      openssl=1.0.2o-r0
+      openssl=1.0.2o-r0 \
+      sudo=1.8.21_p2-r1 \
+      iptables=1.6.1-r1
 
 ENV KUBECTL_VERSION=v1.10.1
 ENV HELM_VERSION=v2.8.2
@@ -35,6 +37,8 @@ RUN wget https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-lin
 RUN wget https://github.com/giantswarm/shipyard/releases/download/${SHIPYARD_VERSION}/shipyard && \
   chmod a+x ./shipyard && \
   mv ./shipyard /usr/local/bin
+
+RUN echo '%e2e-harness ALL=(root) NOPASSWD: /sbin/iptables' | tee -a /etc/sudoers.d/e2e-harness
 
 USER e2e-harness
 

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -90,7 +90,9 @@ func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string, env ..
 	// host1:ip1,host2:ip2...
 	addHostEntries := strings.Split(os.Getenv("ADD_HOSTS"), ",")
 	for _, entry := range addHostEntries {
-		baseArgs = append(baseArgs, "--add-host", entry)
+		if entry != "" {
+			baseArgs = append(baseArgs, "--add-host", entry)
+		}
 	}
 
 	// add environment variables

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -82,6 +83,14 @@ func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string, env ..
 		"-e", "KUBECONFIG=" + harness.DefaultKubeConfig,
 		"--dns", "1.1.1.1",
 		"--entrypoint", entrypoint,
+		"--cap-add", "NET_ADMIN",
+	}
+
+	// add-host entries, the ADD_HOSTS env var will look like:
+	// host1:ip1,host2:ip2...
+	addHostEntries := strings.Split(os.Getenv("ADD_HOSTS"), ",")
+	for _, entry := range addHostEntries {
+		baseArgs = append(baseArgs, "--add-host", entry)
 	}
 
 	// add environment variables


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

We want to be able to test chart-operator bootstrap in cluster-operator without having to spin up a guest cluster, and instead check the creation on the "host cluster" (circleci machine in e2e CI runs, minikube for local runs).

In order to do that we need:
* Redirect calls to domains like `api.${CLUSTER_NAME}.aws.gigantic.io` to `127.0.0.1`
* Forward requests on `127.0.0.1` port `80` (default for guest k8s API) to port `8443` (default for localkube/minikube).

These changes allow both requirements by passing `--add-host` parameters to the test container (first requirement) and setting up iptables in the test container for the unprivileged `e2e-harness` user (second requirement).