### PR TITLE
cluster, cmd: don't copy tty on setup

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -87,6 +87,12 @@ func (c *Cluster) copyMinikubeAssets(homeDir string) error {
 
 	// copy minikube directory
 	walkFn := func(path string, info os.FileInfo, err error) error {
+		if strings.HasSuffix(path, "/tty") {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
 		targetPath := strings.Replace(path, originDir, targetDir, 1)
 		if info.IsDir() {
 			return c.fs.MkdirAll(targetPath, os.ModePerm)


### PR DESCRIPTION
So before the change I got this error:

```
$ e2e-harness setup --remote=false | luigi

I 18-04-27 06:14:10 starting harness initialization | e2e-harness/pkg/harness/harness.go:40
I 18-04-27 06:14:10 finished harness initialization | e2e-harness/pkg/harness/harness.go:65
I 18-04-27 06:14:10 Making minikube assets accessible for the test container | e2e-harness/pkg/cluster/cluster.go:80
Error: open /Users/pawel/.minikube/machines/minikube/tty: permission denied
Usage:
  e2e-harness setup [flags]

Flags:
  -h, --help                      help for setup
      --minikube-version string   Minikube version to use. (default "v0.25.2")
      --name string               CI execution identifier (default "e2e-harness")
      --remote                    use remote cluster (default true)
      --test-dir string           Name of the directory containing executable tests. (default "integration")
```

Which was nonsense.

After intermediate changes in `cmd`:

```
$ e2e-harness setup --remote=false | luigi

I 18-04-27 07:06:52 starting harness initialization | e2e-harness/pkg/harness/harness.go:40
I 18-04-27 07:06:52 finished harness initialization | e2e-harness/pkg/harness/harness.go:65
I 18-04-27 07:06:52 Making minikube assets accessible for the test container | e2e-harness/pkg/cluster/cluster.go:79
E 18-04-27 07:08:01 exiting with status 1 due to error | e2e-harness/cmd/setup.go:51
        /Users/pawel/go/src/github.com/giantswarm/e2e-harness/cmd/setup.go:111:
        /Users/pawel/go/src/github.com/giantswarm/e2e-harness/pkg/tasks/tasks.go:13:
        /Users/pawel/go/src/github.com/giantswarm/e2e-harness/pkg/cluster/cluster.go:52:
        /Users/pawel/go/src/github.com/giantswarm/e2e-harness/pkg/cluster/cluster.go:101:
        /Users/pawel/go/src/github.com/giantswarm/e2e-harness/pkg/cluster/cluster.go:185:
        open /Users/pawel/.minikube/machines/minikube/tty: permission denied
```

So I could debug something, and it turned out that `tty` file shouldn't be passed to `copyFile`. On macOS this is some weird symlink.
