### PR TITLE
remove permissive binding

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -126,9 +126,6 @@ func (p *Project) CommonTearDownSteps() error {
 			Run: "helm reset --force",
 		},
 		Step{
-			Run: "kubectl delete clusterrolebinding permissive-binding",
-		},
-		Step{
 			Run: "kubectl -n kube-system delete sa tiller",
 		},
 		Step{

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -83,9 +83,6 @@ func (p *Project) CommonSetupSteps() error {
 			Run: "kubectl config use-context minikube",
 		},
 		Step{
-			Run: "kubectl create clusterrolebinding permissive-binding --clusterrole cluster-admin --group=system:serviceaccounts",
-		},
-		Step{
 			Run: "kubectl -n kube-system create sa tiller",
 		},
 		Step{


### PR DESCRIPTION
During the transition of our components to RBAC we needed to configure the test cluster with `permissive-binding`, so that the components that were not yet migrated would keep working in the tests. The migration finished a while ago, and now this permissive setting is masking some errors, for instance, chart-operator bootstrap e2e test in cluster-operator should be failing until https://github.com/giantswarm/cluster-operator/pull/93 lands, and it is passing https://circleci.com/gh/giantswarm/cluster-operator/439