### PR TITLE
Fix RBAC kube-dns issues

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -82,6 +82,14 @@ func (p *Project) CommonSetupSteps() error {
 		Step{
 			Run: "kubectl config use-context minikube",
 		},
+		// Fix kube-dns RBAC issues.
+		// Allow kube-dns and other kube-system services full access to the API.
+		// See:
+		// * https://github.com/kubernetes/minikube/issues/1734
+		// * https://github.com/kubernetes/minikube/issues/1722
+		Step{
+			Run: "kubectl create clusterrolebinding cluster-admin:kube-system --clusterrole=cluster-admin --serviceaccount=kube-system:default",
+		},
 		Step{
 			Run: "kubectl -n kube-system create sa tiller",
 		},


### PR DESCRIPTION
With the changes introduced in #70 for removing RBAC permissive-binding we were getting these errors on kube-dns:
```
E0503 07:32:42.846108       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kube-system:default" cannot list endpoints at the cluster scope
E0503 07:32:42.846213       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.Service: services is forbidden: User "system:serviceaccount:kube-system:default" cannot list services at the cluster scope
E0503 07:32:42.846304       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:kube-system:default" cannot list configmaps in the namespace "kube-system"
```
These changes allow kube-system services full access to the API and prevent the above failures, see:
* https://github.com/kubernetes/minikube/issues/1734
* https://github.com/kubernetes/minikube/issues/1722