### PR TITLE
remove afero constraint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -532,6 +532,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9db1d57c6b62456d929953cbd81f15ebb7b99c81ff4f0218968c72f90cb28710"
+  inputs-digest = "1612f419aa75d30c2ead332163157ae9ed8a21fddd8257c9f37f7e8679beaf0f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,10 +43,6 @@
   name = "github.com/giantswarm/versionbundle"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/spf13/afero"
-
-[[constraint]]
   version = "v0.0.1"
   name = "github.com/spf13/cobra"
 


### PR DESCRIPTION
Aims to prevent a dependency conflict when updating e2e-harness dep. We usually don't impose constraints on afero version.