### PR TITLE
Pass filesystem labels to docker volume mount

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -76,8 +76,8 @@ func (d *Docker) baseRun(out io.Writer, entrypoint string, args []string, env ..
 	e2eDir := filepath.Join(filepath.Dir(baseDir), d.dir)
 	baseArgs := []string{
 		"run",
-		"-v", fmt.Sprintf("%s:%s", filepath.Join(baseDir, "workdir"), "/workdir"),
-		"-v", fmt.Sprintf("%s:/e2e", e2eDir),
+		"-v", fmt.Sprintf("%s:%s:z", filepath.Join(baseDir, "workdir"), "/workdir"),
+		"-v", fmt.Sprintf("%s:/e2e:z", e2eDir),
 		"-e", fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", os.Getenv("AWS_ACCESS_KEY_ID")),
 		"-e", fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", os.Getenv("AWS_SECRET_ACCESS_KEY")),
 		"-e", "KUBECONFIG=" + harness.DefaultKubeConfig,


### PR DESCRIPTION
When running e.g. on SELinux enabled system, filesystem labels need to
be passed to docker container in order to permissions work correctly.

These are needed e.g. when running on Fedora Linux with defaults.