### PR TITLE
exposes g8s client for e2etests

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -115,6 +115,11 @@ func (h *Host) DeleteGuestCluster(name, cr, logEntry string) error {
 	return h.WaitForPodLog("giantswarm", logEntry, operatorPodName)
 }
 
+// G8sClient returns the host cluster framework's Giant Swarm client.
+func (h *Host) G8sClient() versioned.Interface {
+	return h.g8sClient
+}
+
 func (h *Host) InstallStableOperator(name, cr, values string) error {
 	err := h.InstallOperator(name, cr, values, ":stable")
 	if err != nil {


### PR DESCRIPTION
This is necessary to improve https://github.com/giantswarm/e2etests/pull/2. 