### PR TITLE
Default the appr client

### DIFF
--- a/pkg/framework/resource/resource.go
+++ b/pkg/framework/resource/resource.go
@@ -35,7 +35,9 @@ func New(config ResourceConfig) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 	if config.ApprClient == nil {
-		config.Logger.Log("level", "warning", "message", fmt.Sprintf("%T.ApprClient is empty, using default", config))
+		config.Logger.Log("level", "debug", "message", fmt.Sprintf("%T.ApprClient is empty", config))
+
+		config.Logger.Log("level", "debug", "message", fmt.Sprintf("using default for %T.ApprClient", config))
 
 		c := apprclient.Config{
 			Fs:     afero.NewOsFs(),


### PR DESCRIPTION
Just an idea I just had: We will most likely use the same config for the appr client in all our e2e tests, so we could just default it most of the time. WDYT?