### PR TITLE
Pull chart from channel instead of release

### DIFF
--- a/pkg/framework/resource/resource.go
+++ b/pkg/framework/resource/resource.go
@@ -71,11 +71,11 @@ func New(config ResourceConfig) (*Resource, error) {
 	return c, nil
 }
 
-func (r *Resource) InstallResource(name, values, version string, conditions ...func() error) error {
+func (r *Resource) InstallResource(name, values, channel string, conditions ...func() error) error {
 	chartValuesEnv := os.ExpandEnv(values)
 	chartname := fmt.Sprintf("%s-chart", name)
 
-	tarball, err := r.apprClient.PullChartTarball(chartname, version)
+	tarball, err := r.apprClient.PullChartTarball(chartname, channel)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/framework/resource/resource.go
+++ b/pkg/framework/resource/resource.go
@@ -75,7 +75,7 @@ func (r *Resource) InstallResource(name, values, version string, conditions ...f
 	chartValuesEnv := os.ExpandEnv(values)
 	chartname := fmt.Sprintf("%s-chart", name)
 
-	tarball, err := r.apprClient.PullChartTarballFromRelease(chartname, version)
+	tarball, err := r.apprClient.PullChartTarball(chartname, version)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
It seems to be more practical to use the channel in most cases. This function isn't used yet but I want to get it straighter, so we can switch over easily.