### PR TITLE
Add WaitForStatus and WaitForVersion to resource package

### DIFF
--- a/pkg/framework/resource/error.go
+++ b/pkg/framework/resource/error.go
@@ -8,3 +8,17 @@ var invalidConfigError = microerror.New("invalid config")
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var releaseStatusNotMatchingError = microerror.New("release status not matching")
+
+// IsReleaseStatusNotMatching asserts releaseStatusNotMatchingError
+func IsReleaseStatusNotMatching(err error) bool {
+	return microerror.Cause(err) == releaseStatusNotMatchingError
+}
+
+var releaseVersionNotMatchingError = microerror.New("release version not matching")
+
+// IsReleaseVersionNotMatching asserts releaseVersionNotMatchingError
+func IsReleaseVersionNotMatching(err error) bool {
+	return microerror.Cause(err) == releaseVersionNotMatchingError
+}

--- a/pkg/framework/resource/resource.go
+++ b/pkg/framework/resource/resource.go
@@ -2,7 +2,9 @@ package resource
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"time"
 
 	"github.com/cenkalti/backoff"
 	"github.com/giantswarm/apprclient"
@@ -91,5 +93,53 @@ func (r *Resource) InstallResource(name, values, channel string, conditions ...f
 		}
 	}
 
+	return nil
+}
+
+func (r *Resource) WaitForStatus(gsHelmClient *helmclient.Client, release string, status string) error {
+	operation := func() error {
+		rc, err := r.helmClient.GetReleaseContent(release)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if rc.Status != status {
+			return microerror.Maskf(releaseStatusNotMatchingError, "waiting for %q, current %q", status, rc.Status)
+		}
+		return nil
+	}
+
+	notify := func(err error, t time.Duration) {
+		log.Printf("getting release status %s: %v", t, err)
+	}
+
+	b := framework.NewExponentialBackoff(framework.ShortMaxWait, framework.LongMaxInterval)
+	err := backoff.RetryNotify(operation, b, notify)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	return nil
+}
+
+func (r *Resource) WaitForVersion(gsHelmClient *helmclient.Client, release string, version string) error {
+	operation := func() error {
+		rh, err := gsHelmClient.GetReleaseHistory(release)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if rh.Version != version {
+			return microerror.Maskf(releaseVersionNotMatchingError, "waiting for %q, current %q", version, rh.Version)
+		}
+		return nil
+	}
+
+	notify := func(err error, t time.Duration) {
+		log.Printf("getting release version %s: %v", t, err)
+	}
+
+	b := framework.NewExponentialBackoff(framework.ShortMaxWait, framework.LongMaxInterval)
+	err := backoff.RetryNotify(operation, b, notify)
+	if err != nil {
+		return microerror.Mask(err)
+	}
 	return nil
 }

--- a/pkg/framework/resource/resource.go
+++ b/pkg/framework/resource/resource.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/giantswarm/apprclient"
-	"github.com/giantswarm/e2e-harness/pkg/framework"
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"k8s.io/helm/pkg/helm"
+
+	"github.com/giantswarm/e2e-harness/pkg/framework"
 )
 
 type ResourceConfig struct {


### PR DESCRIPTION
I'm updating the Ingress Controller chart e2e tests (WIP PR https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/26).

This includes using the `resource` package to install the chart. But I need to wait for the release to be installed. @MarcelMue you've already done this in chart-operator but I think its better to move here.

https://github.com/giantswarm/chart-operator/blob/4b7de9d1e73306f08e34a17b8504e03f1ac07126/integration/release/release.go#L15

I also extracted `WaitForVersion` for completeness.