### PR TITLE
Allow use existing cluster

### DIFF
--- a/cmd/error.go
+++ b/cmd/error.go
@@ -1,0 +1,10 @@
+package cmd
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -18,21 +18,6 @@ import (
 	"github.com/giantswarm/e2e-harness/pkg/wait"
 )
 
-const (
-	// EnvVarK8sApiUrl is the process environment variable representing the
-	// k8s api url for testing cluster.
-	EnvVarK8sApiUrl = "K8S_API_URL"
-	// EnvVarK8sCert is the process environment variable representing the
-	// k8s kubeconfig cert value for testing cluster.
-	EnvVarK8sCert = "K8S_CERT_ENCODED"
-	// EnvVarK8sCert is the process environment variable representing the
-	// k8s kubeconfig ca cert value for testing cluster.
-	EnvVarK8sCertCA = "K8S_CERT_CA_ENCODED"
-	// EnvVarK8sCert is the process environment variable representing the
-	// k8s kubeconfig private key value for testing cluster.
-	EnvVarK8sCertPrivate = "K8S_CERT_PRIVATE_ENCODED"
-)
-
 var (
 	SetupCmd = &cobra.Command{
 		Use:   "setup",

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -131,11 +131,11 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 		Logger:          logger,
 		Fs:              fs,
 		ExistingCluster: existingCluster,
-		RemoteCluster:   remoteCluster,
 		K8sApiUrl:       k8sApiUrl,
 		K8sCert:         k8sCert,
 		K8sCertCA:       k8sCertCA,
 		K8sCertKey:      k8sCertKey,
+		RemoteCluster:   remoteCluster,
 	}
 
 	c := cluster.New(clusterCfg)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -29,6 +29,7 @@ var (
 var (
 	setupCmdTestDir string
 	name            string
+	existingCluster bool
 	remoteCluster   bool
 )
 
@@ -38,7 +39,7 @@ func init() {
 	SetupCmd.Flags().StringVar(&setupCmdTestDir, "test-dir", project.DefaultDirectory, "Name of the directory containing executable tests.")
 	SetupCmd.Flags().StringVar(&name, "name", "e2e-harness", "CI execution identifier")
 	SetupCmd.Flags().BoolVar(&remoteCluster, "remote", true, "use remote cluster")
-	SetupCmd.Flags().BoolVar(&remoteCluster, "existing", false, "can be used with --remote=true to use already existing cluster")
+	SetupCmd.Flags().BoolVar(&existingCluster, "existing", false, "can be used with --remote=true to use already existing cluster")
 }
 
 func runSetup(cmd *cobra.Command, args []string) {
@@ -99,7 +100,7 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 		RemoteCluster: remoteCluster,
 	}
 	h := harness.New(logger, fs, hCfg)
-	c := cluster.New(logger, fs, d, remoteCluster)
+	c := cluster.New(logger, fs, d, existingCluster, remoteCluster)
 
 	// tasks to run
 	bundle := []tasks.Task{

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -38,6 +38,7 @@ func init() {
 	SetupCmd.Flags().StringVar(&setupCmdTestDir, "test-dir", project.DefaultDirectory, "Name of the directory containing executable tests.")
 	SetupCmd.Flags().StringVar(&name, "name", "e2e-harness", "CI execution identifier")
 	SetupCmd.Flags().BoolVar(&remoteCluster, "remote", true, "use remote cluster")
+	SetupCmd.Flags().BoolVar(&remoteCluster, "existing", false, "can be used with --remote=true to use already existing cluster")
 }
 
 func runSetup(cmd *cobra.Command, args []string) {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -97,7 +97,8 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 	}
 	p := project.New(pDeps, pCfg)
 	hCfg := harness.Config{
-		RemoteCluster: remoteCluster,
+		ExistingCluster: existingCluster,
+		RemoteCluster:   remoteCluster,
 	}
 	h := harness.New(logger, fs, hCfg)
 	c := cluster.New(logger, fs, d, existingCluster, remoteCluster)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -136,6 +136,7 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 		K8sCertCA:       k8sCertCA,
 		K8sCertKey:      k8sCertKey,
 		RemoteCluster:   remoteCluster,
+		Runner:          d,
 	}
 
 	c := cluster.New(clusterCfg)

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -86,6 +86,7 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 		Fs:              fs,
 		ExistingCluster: existingCluster,
 		RemoteCluster:   remoteCluster,
+		Runner:          d,
 	}
 	c := cluster.New(clusterCfg)
 

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -80,15 +80,14 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 		Fs:     fs,
 	}
 	p := project.New(pDeps, pCfg)
-	c := cluster.New(logger,
-		fs,
-		d,
-		cfg.ExistingCluster,
-		cfg.RemoteCluster,
-		"",
-		"",
-		"",
-		"")
+
+	clusterCfg := cluster.Config{
+		Logger:          logger,
+		Fs:              fs,
+		ExistingCluster: existingCluster,
+		RemoteCluster:   remoteCluster,
+	}
+	c := cluster.New(clusterCfg)
 
 	bundle := []tasks.Task{}
 

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -80,7 +80,7 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 		Fs:     fs,
 	}
 	p := project.New(pDeps, pCfg)
-	c := cluster.New(logger, fs, d, cfg.RemoteCluster)
+	c := cluster.New(logger, fs, d, cfg.ExistingCluster, cfg.RemoteCluster)
 
 	bundle := []tasks.Task{}
 

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -80,11 +80,19 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 		Fs:     fs,
 	}
 	p := project.New(pDeps, pCfg)
-	c := cluster.New(logger, fs, d, cfg.ExistingCluster, cfg.RemoteCluster)
+	c := cluster.New(logger,
+		fs,
+		d,
+		cfg.ExistingCluster,
+		cfg.RemoteCluster,
+		"",
+		"",
+		"",
+		"")
 
 	bundle := []tasks.Task{}
 
-	if cfg.RemoteCluster {
+	if cfg.RemoteCluster && !cfg.ExistingCluster {
 		bundle = append(bundle, c.Delete)
 	} else {
 		bundle = append(bundle, p.CommonTearDownSteps)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -19,16 +19,17 @@ type Cluster struct {
 	logger          micrologger.Logger
 	runner          runner.Runner
 	fs              afero.Fs
-	remoteCluster   bool
 	existingCluster bool
+	remoteCluster   bool
 }
 
-func New(logger micrologger.Logger, fs afero.Fs, runner runner.Runner, remoteCluster bool) *Cluster {
+func New(logger micrologger.Logger, fs afero.Fs, runner runner.Runner, existingCluster bool, remoteCluster bool) *Cluster {
 	return &Cluster{
-		logger:        logger,
-		runner:        runner,
-		fs:            fs,
-		remoteCluster: remoteCluster,
+		logger:          logger,
+		runner:          runner,
+		fs:              fs,
+		existingCluster: existingCluster,
+		remoteCluster:   remoteCluster,
 	}
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/user"
@@ -11,7 +12,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 
-	"fmt"
 	"github.com/giantswarm/e2e-harness/pkg/harness"
 	"github.com/giantswarm/e2e-harness/pkg/runner"
 )
@@ -257,20 +257,17 @@ current-context: giantswarm-e2e
 preferences: {}
 `
 
-// create kubeconfig from env values for existing cluster
+// createKubeconfig is creating kubeconfig from url and tls assets values for existing cluster
 func (c *Cluster) createKubeconfig(filePath string) error {
-
 	// fill template with values
-	kubeConfigContet := fmt.Sprintf(kubeConfigTmpl, c.k8sApiUrl, c.k8sCertCA, c.k8sCert, c.k8sCertPrivate)
-
-	var aferoFs = afero.NewOsFs()
-
-	f, err := aferoFs.Create(filePath)
+	kubeConfigContent := fmt.Sprintf(kubeConfigTmpl, c.k8sApiUrl, c.k8sCertCA, c.k8sCert, c.k8sCertPrivate)
+	// create file
+	f, err := c.fs.Create(filePath)
 	if err != nil {
 		return microerror.Maskf(err, fmt.Sprintf("Failed to create kubeconfig %s", filePath))
 	}
-
-	_, err = f.WriteString(kubeConfigContet)
+	// write kubeconfig to file
+	_, err = f.WriteString(kubeConfigContent)
 	if err != nil {
 		return microerror.Maskf(err, fmt.Sprintf("Failed to write content of kubeconfig %s", filePath))
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -11,25 +11,36 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 
+	"fmt"
 	"github.com/giantswarm/e2e-harness/pkg/harness"
 	"github.com/giantswarm/e2e-harness/pkg/runner"
 )
 
 type Cluster struct {
-	logger          micrologger.Logger
-	runner          runner.Runner
-	fs              afero.Fs
+	logger        micrologger.Logger
+	runner        runner.Runner
+	fs            afero.Fs
+	remoteCluster bool
+
 	existingCluster bool
-	remoteCluster   bool
+	k8sApiUrl       string
+	k8sCert         string
+	k8sCertCA       string
+	k8sCertPrivate  string
 }
 
-func New(logger micrologger.Logger, fs afero.Fs, runner runner.Runner, existingCluster bool, remoteCluster bool) *Cluster {
+func New(logger micrologger.Logger, fs afero.Fs, runner runner.Runner, existingCluster, remoteCluster bool, k8sApiUrl, k8sCert, k8sCertCA, k8sCertPrivate string) *Cluster {
 	return &Cluster{
-		logger:          logger,
-		runner:          runner,
-		fs:              fs,
+		logger:        logger,
+		runner:        runner,
+		fs:            fs,
+		remoteCluster: remoteCluster,
+
 		existingCluster: existingCluster,
-		remoteCluster:   remoteCluster,
+		k8sApiUrl:       k8sApiUrl,
+		k8sCert:         k8sCert,
+		k8sCertCA:       k8sCertCA,
+		k8sCertPrivate:  k8sCertPrivate,
 	}
 }
 
@@ -38,6 +49,16 @@ func New(logger micrologger.Logger, fs afero.Fs, runner runner.Runner, existingC
 // later access to it
 func (c *Cluster) Create() error {
 	if c.existingCluster {
+		kubeconfigFilePath, err := getKubeConfigPath()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = c.createKubeconfig(kubeconfigFilePath)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		c.logger.Log("info", "Created kubeconfig minikube assets accessible for the test container")
 		return nil
 	}
 	if c.remoteCluster {
@@ -114,7 +135,7 @@ func (c *Cluster) copyMinikubeAssets(homeDir string) error {
 
 	// copy kube config (assumes the current context is minukube)
 	origKubeCfg := filepath.Join(homeDir, ".kube", "config")
-	targetKubeCfg, err := getMinikubeConfigPath()
+	targetKubeCfg, err := getKubeConfigPath()
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -141,7 +162,7 @@ func (c *Cluster) setupMinikubeConfig(homeDir string) error {
 
 	// path is the actual location of the k8s config file that will be used from the
 	// test container
-	path, err := getMinikubeConfigPath()
+	path, err := getKubeConfigPath()
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -177,10 +198,10 @@ func (c *Cluster) setupMinikubeConfig(homeDir string) error {
 	return nil
 }
 
-// getMinikubeConfigPath returns the actual path of the k8s config file that
+// getKubeConfigPath returns the actual path of the k8s config file that
 // will be used by the test container (path from the point of view of the
 // executing e2e-harness binary, not the test container).
-func getMinikubeConfigPath() (string, error) {
+func getKubeConfigPath() (string, error) {
 	baseDir, err := harness.BaseDir()
 	if err != nil {
 		return "", err
@@ -212,4 +233,47 @@ func (c *Cluster) copyFile(orig, dst string) error {
 	err = out.Sync()
 
 	return microerror.Mask(err)
+}
+
+const kubeConfigTmpl string = `
+apiVersion: v1
+kind: Config
+clusters:
+- name: giantswarm-e2e
+  cluster:
+    server: %s
+    certificate-authority-data: %s
+users:
+- name: giantswarm-e2e-user
+  user:
+    client-certificate-data: %s
+    client-key-data: %s
+contexts:
+- name: giantswarm-e2e
+  context:
+    cluster: giantswarm-e2e
+    user: giantswarm-e2e-user
+current-context: giantswarm-e2e
+preferences: {}
+`
+
+// create kubeconfig from env values for existing cluster
+func (c *Cluster) createKubeconfig(filePath string) error {
+
+	// fill template with values
+	kubeConfigContet := fmt.Sprintf(kubeConfigTmpl, c.k8sApiUrl, c.k8sCertCA, c.k8sCert, c.k8sCertPrivate)
+
+	var aferoFs = afero.NewOsFs()
+
+	f, err := aferoFs.Create(filePath)
+	if err != nil {
+		return microerror.Maskf(err, fmt.Sprintf("Failed to create kubeconfig %s", filePath))
+	}
+
+	_, err = f.WriteString(kubeConfigContet)
+	if err != nil {
+		return microerror.Maskf(err, fmt.Sprintf("Failed to write content of kubeconfig %s", filePath))
+	}
+
+	return nil
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -16,10 +16,11 @@ import (
 )
 
 type Cluster struct {
-	logger        micrologger.Logger
-	runner        runner.Runner
-	fs            afero.Fs
-	remoteCluster bool
+	logger          micrologger.Logger
+	runner          runner.Runner
+	fs              afero.Fs
+	remoteCluster   bool
+	existingCluster bool
 }
 
 func New(logger micrologger.Logger, fs afero.Fs, runner runner.Runner, remoteCluster bool) *Cluster {
@@ -35,6 +36,9 @@ func New(logger micrologger.Logger, fs afero.Fs, runner runner.Runner, remoteClu
 // are using a local one, puts in place the required files for
 // later access to it
 func (c *Cluster) Create() error {
+	if c.existingCluster {
+		return nil
+	}
 	if c.remoteCluster {
 		err := c.clusterAction("shipyard -action=start")
 		if err != nil {

--- a/pkg/harness/harness.go
+++ b/pkg/harness/harness.go
@@ -24,7 +24,8 @@ type Harness struct {
 }
 
 type Config struct {
-	RemoteCluster bool `yaml:"remoteCluster"`
+	ExistingCluster bool `yaml:"existingCluster"`
+	RemoteCluster   bool `yaml:"remoteCluster"`
 }
 
 func New(logger micrologger.Logger, fs afero.Fs, cfg Config) *Harness {


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/2440 
for KVM we already have precreated cluster so we don't wanna minikube and we dont wanna setup cluster on aws ( at least for now, maybe in future we will spawn kvm host cluster)

for https://github.com/giantswarm/kvm-operator/pull/522