### PR TITLE
use-custom-k8s-context

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -34,6 +34,7 @@ var (
 	k8sCert         string
 	k8sCertCA       string
 	k8sCertKey      string
+	k8sContext      string
 	remoteCluster   bool
 )
 
@@ -46,6 +47,7 @@ func init() {
 	SetupCmd.Flags().StringVar(&k8sApiUrl, "k8s-api-url", "", "k8s api url for existing cluster")
 	SetupCmd.Flags().StringVar(&k8sCert, "k8s-cert", "", "k8s cert for auth for existing cluster")
 	SetupCmd.Flags().StringVar(&k8sCertCA, "k8s-cert-ca", "", "k8s cert ca for auth for existing cluster")
+	SetupCmd.Flags().StringVar(&k8sCertCA, "k8s-context", "minikube", "k8s context to use")
 	SetupCmd.Flags().StringVar(&k8sCertKey, "k8s-cert-key", "", "k8s cert key for auth for existing cluster")
 	SetupCmd.Flags().BoolVar(&remoteCluster, "remote", true, "use remote cluster")
 }
@@ -110,10 +112,6 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 	pa := patterns.New(logger)
 	w := wait.New(logger, d, pa)
 
-	k8sContext := "minikube"
-	if existingCluster {
-		k8sContext = "giantswarm-e2e"
-	}
 	pCfg := &project.Config{
 		Name:       projectName,
 		K8sContext: k8sContext,

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -110,8 +110,12 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 	pa := patterns.New(logger)
 	w := wait.New(logger, d, pa)
 	pCfg := &project.Config{
-		Name: projectName,
-		Tag:  projectTag,
+		Name:       projectName,
+		K8sContext: "minikube",
+		Tag:        projectTag,
+	}
+	if existingCluster {
+		pCfg.K8sContext = "giantswarm-e2e"
 	}
 	fs := afero.NewOsFs()
 	pDeps := &project.Dependencies{

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -47,7 +47,7 @@ func init() {
 	SetupCmd.Flags().StringVar(&k8sApiUrl, "k8s-api-url", "", "k8s api url for existing cluster")
 	SetupCmd.Flags().StringVar(&k8sCert, "k8s-cert", "", "k8s cert for auth for existing cluster")
 	SetupCmd.Flags().StringVar(&k8sCertCA, "k8s-cert-ca", "", "k8s cert ca for auth for existing cluster")
-	SetupCmd.Flags().StringVar(&k8sCertCA, "k8s-context", "minikube", "k8s context to use")
+	SetupCmd.Flags().StringVar(&k8sContext, "k8s-context", "minikube", "k8s context to use")
 	SetupCmd.Flags().StringVar(&k8sCertKey, "k8s-cert-key", "", "k8s cert key for auth for existing cluster")
 	SetupCmd.Flags().BoolVar(&remoteCluster, "remote", true, "use remote cluster")
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -109,14 +109,17 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 
 	pa := patterns.New(logger)
 	w := wait.New(logger, d, pa)
+
+	k8sContext := "minikube"
+	if existingCluster {
+		k8sContext = "giantswarm-e2e"
+	}
 	pCfg := &project.Config{
 		Name:       projectName,
-		K8sContext: "minikube",
+		K8sContext: k8sContext,
 		Tag:        projectTag,
 	}
-	if existingCluster {
-		pCfg.K8sContext = "giantswarm-e2e"
-	}
+
 	fs := afero.NewOsFs()
 	pDeps := &project.Dependencies{
 		Logger: logger,

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -43,9 +43,10 @@ type Test struct {
 }
 
 type Config struct {
-	Dir  string
-	Name string
-	Tag  string
+	Dir        string
+	K8sContext string
+	Name       string
+	Tag        string
 }
 
 type Dependencies struct {
@@ -80,7 +81,7 @@ func (p *Project) CommonSetupSteps() error {
 	p.logger.Log("info", "executing common setup steps")
 	steps := []Step{
 		Step{
-			Run: "kubectl config use-context minikube",
+			Run: "kubectl config use-context " + p.cfg.K8sContext,
 		},
 		// Fix kube-dns RBAC issues.
 		// Allow kube-dns and other kube-system services full access to the API.

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -79,7 +79,6 @@ func New(deps *Dependencies, cfg *Config) *Project {
 
 func (p *Project) CommonSetupSteps() error {
 	p.logger.Log("info", "executing common setup steps")
-	p.logger.Log("info", fmt.Sprintf("using k8s context: %s", p.cfg.K8sContext))
 	steps := []Step{
 		Step{
 			Run: "kubectl config use-context " + p.cfg.K8sContext,

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -79,6 +79,7 @@ func New(deps *Dependencies, cfg *Config) *Project {
 
 func (p *Project) CommonSetupSteps() error {
 	p.logger.Log("info", "executing common setup steps")
+	p.logger.Log("info", fmt.Sprintf("using k8s context: %s", p.cfg.K8sContext))
 	steps := []Step{
 		Step{
 			Run: "kubectl config use-context " + p.cfg.K8sContext,


### PR DESCRIPTION
By default, e2e-harness has hardcoded `minikube` k8s context so this little change allows use context from existing cluster template

towards e2e for kvm https://github.com/giantswarm/giantswarm/issues/2440