### PR TITLE
disable-port-forward-for-existing-kvm-cluster

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -101,9 +101,10 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 		c := docker.Config{
 			Logger: logger,
 
-			Dir:           setupCmdTestDir,
-			ImageTag:      e2eHarnessTag,
-			RemoteCluster: remoteCluster,
+			Dir:             setupCmdTestDir,
+			ExistingCluster: existingCluster,
+			ImageTag:        e2eHarnessTag,
+			RemoteCluster:   remoteCluster,
 		}
 
 		d = docker.New(c)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -248,8 +248,7 @@ func (c *Cluster) copyFile(orig, dst string) error {
 	return microerror.Mask(err)
 }
 
-const kubeConfigTmpl string = `
-apiVersion: v1
+const kubeConfigTmpl string = `apiVersion: v1
 kind: Config
 clusters:
 - name: giantswarm-e2e

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -17,26 +17,29 @@ import (
 type Config struct {
 	Logger micrologger.Logger
 
-	Dir           string
-	ImageTag      string
-	RemoteCluster bool
+	Dir             string
+	ExistingCluster bool
+	ImageTag        string
+	RemoteCluster   bool
 }
 
 type Docker struct {
 	logger micrologger.Logger
 
-	dir           string
-	imageTag      string
-	remoteCluster bool
+	dir             string
+	existingCluster bool
+	imageTag        string
+	remoteCluster   bool
 }
 
 func New(config Config) *Docker {
 	d := &Docker{
 		logger: config.Logger,
 
-		dir:           config.Dir,
-		imageTag:      config.ImageTag,
-		remoteCluster: config.RemoteCluster,
+		dir:             config.Dir,
+		existingCluster: config.ExistingCluster,
+		imageTag:        config.ImageTag,
+		remoteCluster:   config.RemoteCluster,
 	}
 
 	return d
@@ -46,8 +49,8 @@ func New(config Config) *Docker {
 // setting up the port forwarding to the remote cluster, this command
 // is meant to be used after that cluster has been initialized
 func (d *Docker) RunPortForward(out io.Writer, command string, env ...string) error {
-	if !d.remoteCluster {
-		// no need to port forward in local clusters
+	if !d.remoteCluster || d.existingCluster {
+		// no need to port forward in local clusters or on existing cluster
 		return d.Run(out, command, env...)
 	}
 


### PR DESCRIPTION
disable port forwarding for the `existing cluster` option that is used for KVM