### PR TITLE
fix teardown-steps

### DIFF
--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -60,9 +60,10 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 		c := docker.Config{
 			Logger: logger,
 
-			Dir:           teardownCmdTestDir,
-			ImageTag:      e2eHarnessTag,
-			RemoteCluster: cfg.RemoteCluster,
+			Dir:             teardownCmdTestDir,
+			ExistingCluster: cfg.ExistingCluster,
+			ImageTag:        e2eHarnessTag,
+			RemoteCluster:   cfg.RemoteCluster,
 		}
 
 		d = docker.New(c)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -62,9 +62,10 @@ func runTest(cmd *cobra.Command, args []string) error {
 		c := docker.Config{
 			Logger: logger,
 
-			Dir:           testCmdTestDir,
-			ImageTag:      e2eHarnessTag,
-			RemoteCluster: cfg.RemoteCluster,
+			Dir:             testCmdTestDir,
+			ExistingCluster: cfg.ExistingCluster,
+			ImageTag:        e2eHarnessTag,
+			RemoteCluster:   cfg.RemoteCluster,
 		}
 
 		d = docker.New(c)


### PR DESCRIPTION
similar to this https://github.com/giantswarm/e2e-harness/pull/104
config for docker needs to have the `existingCluster` flag in all steps, found out too late :(