### PR TITLE
dont-install-tiller-for-existing-cluster

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -158,6 +158,5 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 		bundle = append(bundle, p.CommonSetupSteps)
 	}
 
-
 	return microerror.Mask(tasks.Run(bundle))
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -152,7 +152,6 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 		h.Init,
 		h.WriteConfig,
 		c.Create,
-		p.CommonSetupSteps,
 	}
 	if !existingCluster {
 		bundle = append(bundle, p.CommonSetupSteps)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -154,6 +154,10 @@ func runSetupError(cmd *cobra.Command, args []string) error {
 		c.Create,
 		p.CommonSetupSteps,
 	}
+	if !existingCluster {
+		bundle = append(bundle, p.CommonSetupSteps)
+	}
+
 
 	return microerror.Mask(tasks.Run(bundle))
 }

--- a/cmd/teardown.go
+++ b/cmd/teardown.go
@@ -95,7 +95,7 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 
 	if cfg.RemoteCluster && !cfg.ExistingCluster {
 		bundle = append(bundle, c.Delete)
-	} else {
+	} else if !cfg.ExistingCluster {
 		bundle = append(bundle, p.CommonTearDownSteps)
 	}
 


### PR DESCRIPTION
There is no need to install tiller each time for the already existing cluster.  
( parallel e2e test could remove tiller in the middle of another test so rather have it installed from the start and don't do it in e2e)