### PR TITLE
framework: improve unexpected pod status error message

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -492,7 +492,7 @@ func (h *Host) runningPod(namespace, labelSelector string) func() error {
 		pod := pods.Items[0]
 		phase := pod.Status.Phase
 		if phase != v1.PodRunning {
-			return microerror.Maskf(unexpectedStatusPhaseError, "current status: %s", string(phase))
+			return microerror.Maskf(unexpectedStatusPhaseError, "pod selected with %q is in phase %q", labelSelector, string(phase))
 		}
 		return nil
 	}

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -492,7 +492,7 @@ func (h *Host) runningPod(namespace, labelSelector string) func() error {
 		pod := pods.Items[0]
 		phase := pod.Status.Phase
 		if phase != v1.PodRunning {
-			return microerror.Maskf(unexpectedStatusPhaseError, "pod selected with %q is in phase %q instead of %q", labelSelector, string(phase), v1.PodRunning)
+			return microerror.Maskf(unexpectedStatusPhaseError, "pod selected with %q is in phase %q instead of %q", labelSelector, string(phase), string(v1.PodRunning))
 		}
 		return nil
 	}

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -492,7 +492,7 @@ func (h *Host) runningPod(namespace, labelSelector string) func() error {
 		pod := pods.Items[0]
 		phase := pod.Status.Phase
 		if phase != v1.PodRunning {
-			return microerror.Maskf(unexpectedStatusPhaseError, "pod selected with %q is in phase %q", labelSelector, string(phase))
+			return microerror.Maskf(unexpectedStatusPhaseError, "pod selected with %q is in phase %q instead of %q", labelSelector, string(phase), v1.PodRunning)
 		}
 		return nil
 	}


### PR DESCRIPTION
Current output does not tell which pod has the status phase:

    {"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/backoff/notifier.go:13","level":"warning","message":"retrying backoff in '757.214396ms' due to error","stack":"[{/home/circleci/.go_workspace/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/e2e-harness/pkg/framework/host.go:495: current status: Pending} {unexpected status phase error}]","time":"2018-08-13T15:48:19.121857+00:00"}