### PR TITLE
Align default namespace

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultNamespace = "giantswarm"
+	defaultNamespace = "default"
 )
 
 type HostConfig struct {
@@ -464,7 +464,7 @@ func (h *Host) RestConfig() *rest.Config {
 }
 
 func (h *Host) Setup() error {
-	if err := h.CreateNamespace(h.targetNamespace); err != nil {
+	if err := h.CreateNamespace("giantswarm"); err != nil {
 		return microerror.Mask(err)
 	}
 
@@ -483,7 +483,7 @@ func (h *Host) Teardown() {
 	HelmCmd("delete vault --purge")
 	h.k8sClient.CoreV1().
 		Namespaces().
-		Delete(h.targetNamespace, &metav1.DeleteOptions{})
+		Delete("giantswarm", &metav1.DeleteOptions{})
 }
 
 func (h *Host) WaitForPodLog(namespace, needle, podName string) error {

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultNamespace = "default"
+	defaultNamespace = "giantswarm"
 )
 
 type HostConfig struct {
@@ -316,12 +316,12 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	podName, err := h.PodName("giantswarm", fmt.Sprintf("app=%s", name))
+	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = h.filelogger.StartLoggingPod("giantswarm", podName)
+	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -464,7 +464,7 @@ func (h *Host) RestConfig() *rest.Config {
 }
 
 func (h *Host) Setup() error {
-	if err := h.CreateNamespace("giantswarm"); err != nil {
+	if err := h.CreateNamespace(h.targetNamespace); err != nil {
 		return microerror.Mask(err)
 	}
 
@@ -483,7 +483,7 @@ func (h *Host) Teardown() {
 	HelmCmd("delete vault --purge")
 	h.k8sClient.CoreV1().
 		Namespaces().
-		Delete("giantswarm", &metav1.DeleteOptions{})
+		Delete(h.targetNamespace, &metav1.DeleteOptions{})
 }
 
 func (h *Host) WaitForPodLog(namespace, needle, podName string) error {

--- a/pkg/framework/resource/resource.go
+++ b/pkg/framework/resource/resource.go
@@ -15,6 +15,10 @@ import (
 	"github.com/giantswarm/e2e-harness/pkg/framework"
 )
 
+const (
+	defaultNamespace = "default"
+)
+
 type ResourceConfig struct {
 	ApprClient *apprclient.Client
 	HelmClient *helmclient.Client
@@ -59,7 +63,7 @@ func New(config ResourceConfig) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
 	}
 	if config.Namespace == "" {
-		config.Namespace = "giantswarm"
+		config.Namespace = defaultNamespace
 	}
 	c := &Resource{
 		apprClient: config.ApprClient,


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/4029

We were not installing our operators in `giantswarm` and had different namespaces sprinkled around.
I think aligning to `giantswarm` makes sense.