### PR TITLE
Make logger fallback to giantswarm namespace

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -324,8 +324,8 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	//
 	// Final version of the code:
 	//
-	// podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
-	// 	if err != nil {
+	//	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
+	//	if err != nil {
 	//		return microerror.Mask(err)
 	//	}
 	//	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -316,12 +316,20 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	podNamespace := h.targetNamespace
+
 	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
-	if err != nil {
+	if IsNotFound(err) {
+		podNamespace = "giantswarm"
+		podName, err = h.PodName(podNamespace, fmt.Sprintf("app=%s", name))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)
+	err = h.filelogger.StartLoggingPod(podNamespace, podName)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -317,7 +317,7 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 		return microerror.Mask(err)
 	}
 	// TODO introduced: https://github.com/giantswarm/e2e-harness/pull/121
-	// This fallback to h.targetNamespace was introduced because not all our
+	// This fallback from h.targetNamespace was introduced because not all our
 	// operators accept and apply configured namespaces.
 	//
 	// Tracking issue: https://github.com/giantswarm/giantswarm/issues/4123

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -316,6 +316,23 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	// TODO introduced: https://github.com/giantswarm/e2e-harness/pull/121
+	// This fallback to h.targetNamespace was introduced because not all our
+	// operators accept and apply configured namespaces.
+	//
+	// Tracking issue: https://github.com/giantswarm/giantswarm/issues/4123
+	//
+	// Final version of the code:
+	//
+	// podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
+	// 	if err != nil {
+	//		return microerror.Mask(err)
+	//	}
+	//	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)
+	//	if err != nil {
+	//		return microerror.Mask(err)
+	//	}
+	//
 	podNamespace := h.targetNamespace
 
 	podName, err := h.PodName(podNamespace, fmt.Sprintf("app=%s", name))
@@ -333,6 +350,7 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	// TODO end
 
 	return nil
 }

--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -318,7 +318,7 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	}
 	podNamespace := h.targetNamespace
 
-	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
+	podName, err := h.PodName(podNamespace, fmt.Sprintf("app=%s", name))
 	if IsNotFound(err) {
 		podNamespace = "giantswarm"
 		podName, err = h.PodName(podNamespace, fmt.Sprintf("app=%s", name))


### PR DESCRIPTION
We can't currently reliably tell which namespace an operator is going to be installed in. `e2e-harness` overwrites the `namespace` value in the helm values but not all operators actually use that value.

So we have some operators that end up in a namespace we pass in as a value while others do not. This attempts to fallback to the `giantswarm` namespace if we can't find the pod at first.

related issue: https://github.com/giantswarm/giantswarm/issues/4123

I will add a TODO issue to remove this code when the root cause is solved.

towards https://github.com/giantswarm/giantswarm/issues/4029