### PR TITLE
Remove namespace fallback for file logger

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -323,41 +323,15 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	// TODO introduced: https://github.com/giantswarm/e2e-harness/pull/121
-	// This fallback from h.targetNamespace was introduced because not all our
-	// operators accept and apply configured namespaces.
-	//
-	// Tracking issue: https://github.com/giantswarm/giantswarm/issues/4123
-	//
-	// Final version of the code:
-	//
-	//	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
-	//	if err != nil {
-	//		return microerror.Mask(err)
-	//	}
-	//	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)
-	//	if err != nil {
-	//		return microerror.Mask(err)
-	//	}
-	//
-	podNamespace := h.targetNamespace
 
-	podName, err := h.PodName(podNamespace, fmt.Sprintf("app=%s", name))
-	if IsNotFound(err) {
-		podNamespace = "giantswarm"
-		podName, err = h.PodName(podNamespace, fmt.Sprintf("app=%s", name))
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = h.filelogger.StartLoggingPod(podNamespace, podName)
+	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	// TODO end
+	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
https://github.com/giantswarm/giantswarm/issues/4123 got done and all namespaces of our operators are configurable now. We should no longer need to fall back to a static `giantswarm` namespace.