### PR TITLE
Revert "Remove namespace fallback for file logger"

### DIFF
--- a/pkg/framework/host.go
+++ b/pkg/framework/host.go
@@ -323,15 +323,41 @@ func (h *Host) InstallOperator(name, cr, values, version string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	// TODO introduced: https://github.com/giantswarm/e2e-harness/pull/121
+	// This fallback from h.targetNamespace was introduced because not all our
+	// operators accept and apply configured namespaces.
+	//
+	// Tracking issue: https://github.com/giantswarm/giantswarm/issues/4123
+	//
+	// Final version of the code:
+	//
+	//	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
+	//	if err != nil {
+	//		return microerror.Mask(err)
+	//	}
+	//	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)
+	//	if err != nil {
+	//		return microerror.Mask(err)
+	//	}
+	//
+	podNamespace := h.targetNamespace
 
-	podName, err := h.PodName(h.targetNamespace, fmt.Sprintf("app=%s", name))
+	podName, err := h.PodName(podNamespace, fmt.Sprintf("app=%s", name))
+	if IsNotFound(err) {
+		podNamespace = "giantswarm"
+		podName, err = h.PodName(podNamespace, fmt.Sprintf("app=%s", name))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = h.filelogger.StartLoggingPod(podNamespace, podName)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	err = h.filelogger.StartLoggingPod(h.targetNamespace, podName)
-	if err != nil {
-		return microerror.Mask(err)
-	}
+	// TODO end
 
 	return nil
 }


### PR DESCRIPTION
Reverts giantswarm/e2e-harness#129

This does still not work in `aws-operator`. No idea why this is still different. Reopening the issue.