### PR TITLE
release: add some idempotency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -173,11 +173,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3228a56c6d429de153928f005709174e3606fc5d97ecfea612cf33413aa5ded6"
+  digest = "1:0d9889590f61e199b7788b3dced99ba9d2ea834b0937c4182c16c59abeb07a3a"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
   pruneopts = "UT"
-  revision = "cc5508a1d97cba484638bba1081a86a6f5a02ffa"
+  revision = "07e6b202dd464bad604e04b30f05df9e2821a4b1"
 
 [[projects]]
   branch = "master"

--- a/pkg/release/error.go
+++ b/pkg/release/error.go
@@ -1,6 +1,9 @@
 package release
 
-import "github.com/giantswarm/microerror"
+import (
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+)
 
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
@@ -20,13 +23,12 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
-var releaseNotFoundError = &microerror.Error{
-	Kind: "releaseNotFoundError",
+func IsReleaseAlreadyExists(err error) bool {
+	return helmclient.IsReleaseAlreadyExists(err)
 }
 
-// IsReleaseNotFound asserts releaseNotFoundError.
 func IsReleaseNotFound(err error) bool {
-	return microerror.Cause(err) == releaseNotFoundError
+	return helmclient.IsReleaseNotFound(err)
 }
 
 var releaseStatusNotMatchingError = &microerror.Error{
@@ -47,13 +49,12 @@ func IsReleaseVersionNotMatching(err error) bool {
 	return microerror.Cause(err) == releaseVersionNotMatchingError
 }
 
-var tillerNotFoundError = &microerror.Error{
-	Kind: "tillerNotFoundError",
+func IsTarballNotFound(err error) bool {
+	return helmclient.IsTarballNotFound(err)
 }
 
-// IsTillerNotFound asserts tillerNotFoundError.
 func IsTillerNotFound(err error) bool {
-	return microerror.Cause(err) == tillerNotFoundError
+	return helmclient.IsTillerNotFound(err)
 }
 
 var tooManyResultsError = &microerror.Error{

--- a/pkg/release/error.go
+++ b/pkg/release/error.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
 )
 
@@ -23,12 +22,22 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
-func IsReleaseAlreadyExists(err error) bool {
-	return helmclient.IsReleaseAlreadyExists(err)
+var releaseAlreadyExistsError = &microerror.Error{
+	Kind: "releaseAlreadyExistsError",
 }
 
+// IsReleaseAlreadyExists asserts releaseAlreadyExistsError.
+func IsReleaseAlreadyExists(err error) bool {
+	return microerror.Cause(err) == releaseAlreadyExistsError
+}
+
+var releaseNotFoundError = &microerror.Error{
+	Kind: "releaseNotFoundError",
+}
+
+// IsReleaseNotFound asserts releaseNotFoundError.
 func IsReleaseNotFound(err error) bool {
-	return helmclient.IsReleaseNotFound(err)
+	return microerror.Cause(err) == releaseNotFoundError
 }
 
 var releaseStatusNotMatchingError = &microerror.Error{
@@ -49,12 +58,22 @@ func IsReleaseVersionNotMatching(err error) bool {
 	return microerror.Cause(err) == releaseVersionNotMatchingError
 }
 
-func IsTarballNotFound(err error) bool {
-	return helmclient.IsTarballNotFound(err)
+var tarballNotFoundError = &microerror.Error{
+	Kind: "tarballNotFoundError",
 }
 
+// IsTarballNotFound asserts tarballNotFoundError.
+func IsTarballNotFound(err error) bool {
+	return microerror.Cause(err) == tarballNotFoundError
+}
+
+var tillerNotFoundError = &microerror.Error{
+	Kind: "tillerNotFoundError",
+}
+
+// IsTillerNotFound asserts tillerNotFoundError.
 func IsTillerNotFound(err error) bool {
-	return helmclient.IsTillerNotFound(err)
+	return microerror.Cause(err) == tillerNotFoundError
 }
 
 var tooManyResultsError = &microerror.Error{

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -132,9 +132,9 @@ func (r *Release) Delete(ctx context.Context, name string) error {
 
 	err := r.helmClient.DeleteRelease(releaseName, helm.DeletePurge(true))
 	if helmclient.IsReleaseNotFound(err) {
-		return microerror.Mask(err)
+		return microerror.Maskf(releaseNotFoundError, "failed to delete release %#q", name)
 	} else if helmclient.IsTillerNotFound(err) {
-		return microerror.Mask(err)
+		return microerror.Mask(tillerNotFoundError)
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -128,8 +128,6 @@ func (r *Release) Condition() ConditionSet {
 func (r *Release) Delete(ctx context.Context, name string) error {
 	releaseName := fmt.Sprintf("%s-%s", r.namespace, name)
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", releaseName))
-
 	err := r.helmClient.DeleteRelease(releaseName, helm.DeletePurge(true))
 	if helmclient.IsReleaseNotFound(err) {
 		return microerror.Maskf(releaseNotFoundError, "failed to delete release %#q", name)
@@ -138,8 +136,6 @@ func (r *Release) Delete(ctx context.Context, name string) error {
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", releaseName))
 
 	return nil
 }
@@ -211,8 +207,6 @@ func (r *Release) EnsureInstalled(ctx context.Context, name string, version Vers
 func (r *Release) Install(ctx context.Context, name string, version Version, values string, conditions ...func() error) error {
 	releaseName := fmt.Sprintf("%s-%s", r.namespace, name)
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating release %#q", releaseName))
-
 	var err error
 
 	tarball, err := r.pullTarball(fmt.Sprintf("%s-chart", name), version)
@@ -233,8 +227,6 @@ func (r *Release) Install(ctx context.Context, name string, version Version, val
 	if err != nil {
 		return microerror.Mask(err)
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created release %#q", releaseName))
 
 	return nil
 }

--- a/vendor/github.com/giantswarm/helmclient/.gitignore
+++ b/vendor/github.com/giantswarm/helmclient/.gitignore
@@ -1,2 +1,3 @@
 .e2e-harness
 integration/test/**/*-e2e
+integration/test/**/*.tar.gz

--- a/vendor/github.com/giantswarm/helmclient/Gopkg.lock
+++ b/vendor/github.com/giantswarm/helmclient/Gopkg.lock
@@ -46,14 +46,6 @@
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
-  name = "github.com/coreos/go-semver"
-  packages = ["semver"]
-  pruneopts = "UT"
-  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
-  version = "v0.2.0"
-
-[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -128,6 +120,21 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:988cfde37f089c50ba1ac8a1032c3f81d2ac0359e1872093b946a30139665eb6"
+  name = "github.com/dsnet/compress"
+  packages = [
+    ".",
+    "bzip2",
+    "bzip2/internal/sais",
+    "internal",
+    "internal/errors",
+    "internal/prefix",
+  ]
+  pruneopts = "UT"
+  revision = "cc9eb1d7ad760af14e8f918698f745e80377af4f"
+
+[[projects]]
+  branch = "master"
   digest = "1:5e0da1aba1a7b125f46e6ddca43e98b40cf6eaea3322b016c331cf6afe53c30a"
   name = "github.com/exponent-io/jsonpath"
   packages = ["."]
@@ -152,23 +159,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:910fa8591d50ee561e953624cb1d777ba0f89f6c72d0db58dc85010130fa31ac"
-  name = "github.com/giantswarm/apiextensions"
-  packages = [
-    "pkg/apis/core/v1alpha1",
-    "pkg/apis/example/v1alpha1",
-    "pkg/apis/provider/v1alpha1",
-    "pkg/clientset/versioned",
-    "pkg/clientset/versioned/scheme",
-    "pkg/clientset/versioned/typed/core/v1alpha1",
-    "pkg/clientset/versioned/typed/example/v1alpha1",
-    "pkg/clientset/versioned/typed/provider/v1alpha1",
-  ]
-  pruneopts = "UT"
-  revision = "de2e518b9b9ce196838462ab602febb94e6dafdf"
-
-[[projects]]
-  branch = "master"
   digest = "1:aee5f8435859ee2e6c032c21d92b3b4853cd81387a3738ac1ac20c85cf3ab560"
   name = "github.com/giantswarm/backoff"
   packages = ["."]
@@ -177,15 +167,19 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:61741ecc81c082d51a448d70eefd55fc7c95b96df120f9cc4c912a086feee3a2"
+  digest = "1:b40633b8a09feb7c61a64d01302dd96da21dd3872fee968cbc762170b120234d"
   name = "github.com/giantswarm/e2e-harness"
-  packages = [
-    "pkg/framework",
-    "pkg/framework/filelogger",
-    "pkg/harness",
-  ]
+  packages = ["pkg/harness"]
   pruneopts = "UT"
   revision = "8c4c798088217968915821ef7ffb4d11d8add062"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b50befcc0b01f8000103d2c07a8b47be2547d272a01b8689cc044281d48fe069"
+  name = "github.com/giantswarm/e2esetup"
+  packages = ["k8s"]
+  pruneopts = "UT"
+  revision = "fbdbd487bc645dcb941f3f889a6db3345947fe3e"
 
 [[projects]]
   branch = "master"
@@ -224,14 +218,6 @@
   revision = "22dc3b5565d150e1f94fbed50df3baf6cd40fac9"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e9b2472b310a35332ee67b9189452b51c19599d249bd25440365cd97c97d5a98"
-  name = "github.com/giantswarm/versionbundle"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "9a4f3249a5b5a080d13f1db2580cf09ba5d14ca1"
-
-[[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"
   name = "github.com/go-kit/kit"
   packages = ["log"]
@@ -246,14 +232,6 @@
   pruneopts = "UT"
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
-
-[[projects]]
-  digest = "1:b7fc4c3fd91df516486f53cc86f4b55a0c815782dbe852c5a19cce8e6c577aac"
-  name = "github.com/go-resty/resty"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "d4920dcf5b7689548a6db640278a9b35a5b48ec6"
-  version = "v1.9.1"
 
 [[projects]]
   digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
@@ -323,19 +301,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c42fb0b13261a9bcd08451ee1859e61bea33aa6743916a2e3fb61f33ff6b25c7"
-  name = "github.com/google/go-github"
-  packages = ["github"]
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  name = "github.com/golang/snappy"
+  packages = ["."]
   pruneopts = "UT"
-  revision = "dd29b543e14c33e6373773f2c5ea008b29aeac95"
-
-[[projects]]
-  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
-  name = "github.com/google/go-querystring"
-  packages = ["query"]
-  pruneopts = "UT"
-  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
-  version = "v1.0.0"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
   branch = "master"
@@ -433,6 +403,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:d6f988e7296cebe16d9c405b73bee34da871b382f7438c811279614a725239ae"
+  name = "github.com/mholt/archiver"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "de0d89e255e17c8d75a40122055763e743ab0593"
+  version = "v2.1"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -449,6 +427,14 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:b93a939355dc613ca1c23bf39f6d4c207da431a31dd8af001cc334ad24cab9d3"
+  name = "github.com/nwaples/rardecode"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "cc3e4b2381762c56dbcdf9f93be03349a1dc1c14"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
@@ -463,6 +449,17 @@
   pruneopts = "UT"
   revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
   version = "v1.2"
+
+[[projects]]
+  digest = "1:e39a5ee8fcbec487f8fc68863ef95f2b025e0739b0e4aa55558a2b4cf8f0ecf0"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = "UT"
+  revision = "635575b42742856941dbc767b44905bb9ba083f6"
+  version = "v2.0.7"
 
 [[projects]]
   digest = "1:b6221ec0f8903b556e127c449e7106b63e6867170c2d10a7c058623d086f2081"
@@ -533,6 +530,19 @@
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:4aeb3860275fa1fd60cccfb5a6ef85da438bf17402e1e84412ade4d4b55066a0"
+  name = "github.com/ulikunitz/xz"
+  packages = [
+    ".",
+    "internal/hash",
+    "internal/xlog",
+    "lzma",
+  ]
+  pruneopts = "UT"
+  revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
+  version = "v0.5.4"
+
+[[projects]]
   branch = "master"
   digest = "1:8e241498e35f550e5192ee6b1f6ff2c0a7ffe81feff9541d297facffe1383979"
   name = "golang.org/x/crypto"
@@ -547,40 +557,19 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1e5a14e360f8d47cb1aadb7235bae7e8b965b841b9d1a3d639318733c47f5597"
+  digest = "1:505dbee0833715a72a529bb57c354826ad42a4496fad787fa143699b4de1a6d0"
   name = "golang.org/x/net"
   packages = [
     "context",
-    "context/ctxhttp",
     "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "publicsuffix",
     "trace",
   ]
   pruneopts = "UT"
   revision = "146acd28ed5894421fb5aac80ca93bc1b1f46f87"
-
-[[projects]]
-  branch = "master"
-  digest = "1:28b360454e161aae382c007449bcb1296087b5b52b4f37623bba0f9f9d7207f4"
-  name = "golang.org/x/oauth2"
-  packages = [
-    ".",
-    "internal",
-  ]
-  pruneopts = "UT"
-  revision = "c57b0facaced709681d9f90397429b9430a74754"
-
-[[projects]]
-  branch = "master"
-  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
-  name = "golang.org/x/sync"
-  packages = ["errgroup"]
-  pruneopts = "UT"
-  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
@@ -629,22 +618,6 @@
   packages = ["rate"]
   pruneopts = "UT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
-
-[[projects]]
-  digest = "1:6247f76e55a1e1a5c19a81e2d4b4dff6730461eeb5bbb0a16dd4a8ec8637ee93"
-  name = "google.golang.org/appengine"
-  packages = [
-    "internal",
-    "internal/base",
-    "internal/datastore",
-    "internal/log",
-    "internal/remote_api",
-    "internal/urlfetch",
-    "urlfetch",
-  ]
-  pruneopts = "UT"
-  revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
-  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -757,13 +730,9 @@
   version = "kubernetes-1.10.4"
 
 [[projects]]
-  digest = "1:8470a20b4ff580042a40b3cabc77f56e3f5630bc2ff13236dcfdec96d4ff1b7d"
+  digest = "1:b46a162d7c7e9117ae2dd9a73ee4dc2181ad9ea9d505fd7c5eb63c96211dc9dd"
   name = "k8s.io/apiextensions-apiserver"
-  packages = [
-    "pkg/apis/apiextensions",
-    "pkg/apis/apiextensions/v1beta1",
-    "pkg/features",
-  ]
+  packages = ["pkg/features"]
   pruneopts = "UT"
   revision = "8e7f43002fec5394a8d96ebca781aa9d4b37aaef"
   version = "kubernetes-1.10.4"
@@ -1008,22 +977,6 @@
   version = "v2.8.2"
 
 [[projects]]
-  digest = "1:2af67bd2524aa5fce3cb4bd6e20fbf773b8cf5a9dfc0d1bea7441d98d55f37b5"
-  name = "k8s.io/kube-aggregator"
-  packages = [
-    "pkg/apis/apiregistration",
-    "pkg/apis/apiregistration/v1",
-    "pkg/apis/apiregistration/v1beta1",
-    "pkg/client/clientset_generated/clientset",
-    "pkg/client/clientset_generated/clientset/scheme",
-    "pkg/client/clientset_generated/clientset/typed/apiregistration/v1",
-    "pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1",
-  ]
-  pruneopts = "UT"
-  revision = "239337b3ca87b9f2ce4d2f03b7a5ed985ffa8206"
-  version = "kubernetes-1.10.4"
-
-[[projects]]
   branch = "master"
   digest = "1:a2c842a1e0aed96fd732b535514556323a6f5edfded3b63e5e0ab1bce188aa54"
   name = "k8s.io/kube-openapi"
@@ -1215,13 +1168,14 @@
     "github.com/Azure/go-autorest/autorest",
     "github.com/docker/distribution/reference",
     "github.com/giantswarm/backoff",
-    "github.com/giantswarm/e2e-harness/pkg/framework",
     "github.com/giantswarm/e2e-harness/pkg/harness",
+    "github.com/giantswarm/e2esetup/k8s",
     "github.com/giantswarm/errors/guest",
     "github.com/giantswarm/k8sportforward",
     "github.com/giantswarm/microerror",
     "github.com/giantswarm/micrologger",
     "github.com/giantswarm/micrologger/microloggertest",
+    "github.com/mholt/archiver",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/vendor/github.com/giantswarm/helmclient/Gopkg.toml
+++ b/vendor/github.com/giantswarm/helmclient/Gopkg.toml
@@ -52,6 +52,10 @@ required = [
 
 [[constraint]]
   branch = "master"
+  name = "github.com/giantswarm/e2esetup"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/giantswarm/errors"
 
 [[constraint]]
@@ -85,6 +89,10 @@ required = [
 [[constraint]]
   name = "k8s.io/helm"
   version = "=2.8.2"
+
+[[constraint]]
+  name = "github.com/mholt/archiver"
+  version = "=2.1.0"
 
 
 

--- a/vendor/github.com/giantswarm/helmclient/README.md
+++ b/vendor/github.com/giantswarm/helmclient/README.md
@@ -2,3 +2,14 @@
 
 # helmclient
 Package helmclient implements Helm related primitives to work against Tiller.
+
+## Projects using `helmclient`
+
+### Test libraries
+
+- https://github.com/giantswarm/e2e-harness
+
+### Services & operators
+
+- https://github.com/giantswarm/chart-operator
+- https://github.com/giantswarm/cluster-operator

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -1,6 +1,7 @@
 package helmclient
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/giantswarm/microerror"
@@ -85,6 +86,32 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
+var (
+	releaseAlreadyExistsRegexp = regexp.MustCompile(`release named \S+ already exists`)
+)
+
+var releaseAlreadyExistsError = &microerror.Error{
+	Kind: "releaseAlreadyExistsError",
+}
+
+// IsReleaseAlreadyExists asserts releaseAlreadyExistsError.
+func IsReleaseAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == releaseAlreadyExistsError {
+		return true
+	}
+	if releaseAlreadyExistsRegexp.MatchString(c.Error()) {
+		return true
+	}
+
+	return false
+}
+
 const (
 	releaseNotFoundErrorPrefix = "No such release:"
 	releaseNotFoundErrorSuffix = "not found"
@@ -109,6 +136,32 @@ func IsReleaseNotFound(err error) bool {
 		return true
 	}
 	if c == releaseNotFoundError {
+		return true
+	}
+
+	return false
+}
+
+var (
+	tarballNotFoundRegexp = regexp.MustCompile(`stat \S+: no such file or directory`)
+)
+
+var tarballNotFoundError = &microerror.Error{
+	Kind: "tarballNotFoundError",
+}
+
+// IsTarballNotFound asserts tarballNotFoundError.
+func IsTarballNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == tarballNotFoundError {
+		return true
+	}
+	if tarballNotFoundRegexp.MatchString(c.Error()) {
 		return true
 	}
 

--- a/vendor/github.com/giantswarm/helmclient/helmclient.go
+++ b/vendor/github.com/giantswarm/helmclient/helmclient.go
@@ -394,7 +394,9 @@ func (c *Client) InstallFromTarball(path, ns string, options ...helmclient.Insta
 		release, err := c.newHelmClientFromTunnel(t).InstallRelease(path, ns, options...)
 		if IsCannotReuseRelease(err) {
 			return backoff.Permanent(microerror.Mask(err))
-		} else if IsReleaseNotFound(err) {
+		} else if IsReleaseAlreadyExists(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsTarballNotFound(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if err != nil {
 			if IsInvalidGZipHeader(err) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4481.

Next steps are to make filelogger idempotent. And start logging operator pods if release name has suffix `-operator`. That way we can get rid of `InstallOperator` long term. Also we'll have to expose `CRDExists` condition.