### PR TITLE
release: make sure pod is Running before streaming its logs

### DIFF
--- a/pkg/release/condition_set.go
+++ b/pkg/release/condition_set.go
@@ -86,7 +86,7 @@ func (c *conditionSet) PodExists(ctx context.Context, namespace, labelSelector s
 
 			return nil
 		}
-		b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+		b := backoff.NewExponential(backoff.MediumMaxWait, backoff.LongMaxInterval)
 
 		err := backoff.Retry(o, b)
 		if err != nil {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -266,14 +266,21 @@ func (r *Release) InstallOperator(ctx context.Context, name string, version Vers
 	//
 	podNamespace := r.namespace
 
-	podName, err := r.podName(podNamespace, fmt.Sprintf("app=%s", name))
+	labelSelector := fmt.Sprintf("app=%s", name)
+
+	podName, err := r.podName(podNamespace, labelSelector)
 	if IsNotFound(err) {
 		podNamespace = "giantswarm"
-		podName, err = r.podName(podNamespace, fmt.Sprintf("app=%s", name))
+		podName, err = r.podName(podNamespace, labelSelector)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.Condition().PodExists(ctx, podNamespace, labelSelector)
+	if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -279,7 +279,7 @@ func (r *Release) InstallOperator(ctx context.Context, name string, version Vers
 		return microerror.Mask(err)
 	}
 
-	err = r.Condition().PodExists(ctx, podNamespace, labelSelector)
+	err = r.Condition().PodExists(ctx, podNamespace, labelSelector)()
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4355

I noticed that in two builds already:

```
E 10/25 14:23:24 setup stage failed | kvm-operator/integration/setup/setup.go:26
	/home/circleci/.go_workspace/src/github.com/giantswarm/kvm-operator/integration/setup/setup.go:55: 
	/home/circleci/.go_workspace/src/github.com/giantswarm/kvm-operator/integration/setup/common.go:51: 
	/home/circleci/.go_workspace/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/e2e-harness/pkg/release/release.go:282: 
	/home/circleci/.go_workspace/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/e2e-harness/pkg/internal/filelogger/filelogger.go:97: 
	/home/circleci/.go_workspace/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/e2e-harness/pkg/internal/filelogger/filelogger.go:88: 
	container "cert-operator" in pod "cert-operator-857cd66f8b-xv96s" is waiting to start: ContainerCreating
```