### PR TITLE
release: fix r.Delete error handling

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -158,7 +158,7 @@ func (r *Release) EnsureDeleted(ctx context.Context, name string, conditions ...
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", name))
 
 		err := r.Delete(ctx, name)
-		if helmclient.IsReleaseNotFound(err) {
+		if IsReleaseNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("release %#q already deleted", name))
 		} else if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4355.

Fixes errors like:

```
	recreate_cluster_test.go:35: expected <nil> got [{/home/circleci/.go_workspace/src/github.com/giantswarm/aws-operator/integration/setup/tenant_cluster.go:43: } {/home/circleci/.go_workspace/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/e2e-harness/pkg/release/release.go:164: } {/home/circleci/.go_workspace/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/e2e-harness/pkg/release/release.go:144: failed to delete release `apiextensions-aws-config-e2e`} {release not found error}]
```

From build: https://circleci.com/gh/giantswarm/aws-operator/13095