### PR TITLE
circleci: disable e2eRemoteTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,23 +67,27 @@ jobs:
         command: ./e2e-harness teardown
         when: always
 
-  e2eRemoteTest:
-    working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/e2e-harness
-    machine: true
-    steps:
-    - checkout
-
-    - attach_workspace:
-        at: .
-
-    - run: ./e2e-harness setup
-
-    - run: ./e2e-harness test
-
-    - run:
-        name: Finish with cleanup, no matter if the test succeeded or not
-        command: ./e2e-harness teardown
-        when: always
+ # TODO investiage why the test is failing.
+ #
+ #  See https://github.com/giantswarm/giantswarm/issues/4648
+ #
+ #e2eRemoteTest:
+ #  working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/e2e-harness
+ #  machine: true
+ #  steps:
+ #  - checkout
+ #
+ #  - attach_workspace:
+ #      at: .
+ #
+ #  - run: ./e2e-harness setup
+ #
+ #  - run: ./e2e-harness test
+ #
+ #  - run:
+ #      name: Finish with cleanup, no matter if the test succeeded or not
+ #      command: ./e2e-harness teardown
+ #      when: always
 
   github-release:
     working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/e2e-harness
@@ -107,14 +111,22 @@ workflows:
       - e2eLocalSubDirTest:
           requires:
           - build
-      - e2eRemoteTest:
-          requires:
-          - build
+     # TODO investiage why the test is failing.
+     #
+     #  See https://github.com/giantswarm/giantswarm/issues/4648
+     #
+     #- e2eRemoteTest:
+     #    requires:
+     #    - build
       - github-release:
           requires:
             - e2eLocalTest
             - e2eLocalSubDirTest
-            - e2eRemoteTest
+           # TODO investiage why the test is failing.
+           #
+           #  See https://github.com/giantswarm/giantswarm/issues/4648
+           #
+           #- e2eRemoteTest
           filters:
             branches:
               only: master


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4648

This test is most likely related to shipyard. This is a component to run
remote e2e control planes in AWS IIRC. Tests stopped to work out of the
sudden. We need to investigate. I will disable those tests for now.

We also need to consider if we still need shipyard at all. It was
abandoned for a while since we use localkube. But it still may come in
handy if we need to write vault encrypter tests in aws-operator.

Example build: https://circleci.com/gh/giantswarm/e2e-harness/2179