### PR TITLE
release: wait for helm updates

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -344,7 +344,7 @@ func (r *Release) Update(ctx context.Context, name string, chartInfo ChartInfo, 
 		return microerror.Mask(err)
 	}
 
-	err = r.helmClient.UpdateReleaseFromTarball(releaseName, tarballPath, helm.UpdateValueOverrides([]byte(values)))
+	err = r.helmClient.UpdateReleaseFromTarball(releaseName, tarballPath, helm.UpdateValueOverrides([]byte(values)), helm.UpgradeWait(true))
 	if helmclient.IsReleaseAlreadyExists(err) {
 		return microerror.Maskf(releaseAlreadyExistsError, "failed to update release %#q", releaseName)
 	} else if helmclient.IsTarballNotFound(err) {


### PR DESCRIPTION
I just saw it isn't compatible with `Install` which does:

```
err = r.helmClient.InstallFromTarball(tarballPath, r.namespace, helm.ReleaseName(releaseName), helm.ValueOverrides([]byte(values)), helm.InstallWait(true))
```