### PR TITLE
dockerfile: fix unsatisfiable constraints: openssl-1.0.2q-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk -Uuv add --update --no-cache \
       less=530-r0 \
       libffi-dev=3.2.1-r4 \
       openssh-client=7.7_p1-r3 \
-      openssl=1.0.2p-r0 \
+      openssl \
       sudo=1.8.23-r2 \
       iptables=1.6.2-r0
 


### PR DESCRIPTION
Fixes CI failing with:

 	---> Running in 4c3bbf24f5e3
 	fetch
 	http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
 	fetch
 	http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
 	ERROR: unsatisfiable constraints:
 	  openssl-1.0.2q-r0:
 	      breaks: world[openssl=1.0.2p-r0]
 	      The command '/bin/sh -c apk -Uuv add --update --no-cache
 	      bash=4.4.19-r1       build-base=0.5-r1       git
 	      jq=1.6_rc1-r1       less=530-r0       libffi-dev=3.2.1-r4
 	      openssh-client=7.7_p1-r3       openssl=1.0.2p-r0
 	      sudo=1.8.23-r2       iptables=1.6.2-r0' returned a non-zero code:
 	      1
 	      2018/11/22 14:37:27 generating Junit report at:
 	      /tmp/results/golang/results.xml
 	      2018/11/22 14:37:27 could not execute workflow: <nil>
 	      Exited with code 1