### PR TITLE
docker: delete Rm config leftover

### DIFF
--- a/pkg/internal/docker/run.go
+++ b/pkg/internal/docker/run.go
@@ -8,7 +8,6 @@ import (
 )
 
 type RunConfig struct {
-	Rm               bool
 	Volumes          []string
 	Env              []string
 	WorkingDirectory string


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4753.

Follow up of https://github.com/giantswarm/e2e-harness/pull/170.
I noticed when hitting merge button...