### PR TITLE
Increase release.waitForConditions timeout to 10m

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -469,7 +469,7 @@ func (r *Release) waitForConditions(ctx context.Context, conditions ...func() er
 
 			return nil
 		}
-		b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+		b := backoff.NewExponential(backoff.MediumMaxWait, backoff.ShortMaxInterval)
 		n := backoff.NewNotifier(r.logger, ctx)
 
 		err = backoff.RetryNotify(o, b, n)


### PR DESCRIPTION
release.waitForConditions is used e.g. for ensuring that API secret gets
deleted after corresponding chart is deleted. Occasionally it seems that
it takes moderately long time for cert-operator to get execution time
and pick up the delete event so we give some room for it to operate by
increasing wait timeout value.