### PR TITLE
Nodes ready

### DIFF
--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -145,13 +145,13 @@ func (g *Guest) Initialize() error {
 // Constructing the frameworks can be done right away but setting them up can
 // only happen as soon as certain requirements have been met. A requirement for
 // the guest framework is a set up host cluster.
-func (g *Guest) Setup() error {
+func (g *Guest) Setup(ctx context.Context) error {
 	err := g.Initialize()
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = g.WaitForGuestReady()
+	err = g.WaitForGuestReady(ctx)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -213,7 +213,7 @@ func (g *Guest) WaitForAPIUp() error {
 	return nil
 }
 
-func (g *Guest) WaitForGuestReady() error {
+func (g *Guest) WaitForGuestReady(ctx context.Context) error {
 	var err error
 
 	err = g.WaitForAPIUp()
@@ -221,7 +221,7 @@ func (g *Guest) WaitForGuestReady() error {
 		return microerror.Mask(err)
 	}
 
-	err = g.WaitForNodesUp(minimumNodesReady)
+	err = g.WaitForNodesReady(ctx, minimumNodesReady)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -238,17 +238,17 @@ func (g *Guest) WaitForNodesReady(ctx context.Context, expectedNodes int) error 
 			return microerror.Mask(err)
 		}
 
-		var readyNodes int
+		var nodesReady int
 		for _, n := range nodes.Items {
 			for _, c := range n.Status.Conditions {
 				if c.Type == v1.NodeReady && c.Status == v1.ConditionTrue {
-					readyNodes++
+					nodesReady++
 				}
 			}
 		}
 
-		if readyNodes < expectedNodes {
-			return microerror.Maskf(waitError, "found %d/%d k8s nodes in %#q state", readyNodes, len(nodes.Items), v1.NodeReady)
+		if nodesReady < expectedNodes {
+			return microerror.Maskf(waitError, "found %d/%d k8s nodes in %#q state but %d are expected", nodesReady, len(nodes.Items), v1.NodeReady, expectedNodes)
 		}
 
 		return nil

--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -228,7 +228,7 @@ func (g *Guest) WaitForGuestReady() error {
 	return nil
 }
 
-func (g *Guest) WaitForNodesUp(numberOfNodes int) error {
+func (g *Guest) WaitForNodesReady(numberOfNodes int) error {
 	g.logger.Log("level", "debug", "message", fmt.Sprintf("waiting for %d k8s nodes to be in %#q state", numberOfNodes, v1.NodeReady))
 
 	o := func() error {

--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -228,8 +229,8 @@ func (g *Guest) WaitForGuestReady() error {
 	return nil
 }
 
-func (g *Guest) WaitForNodesReady(numberOfNodes int) error {
-	g.logger.Log("level", "debug", "message", fmt.Sprintf("waiting for %d k8s nodes to be in %#q state", numberOfNodes, v1.NodeReady))
+func (g *Guest) WaitForNodesReady(ctx context.Context, numberOfNodes int) error {
+	g.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for %d k8s nodes to be in %#q state", numberOfNodes, v1.NodeReady))
 
 	o := func() error {
 		nodes, err := g.k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
@@ -257,7 +258,7 @@ func (g *Guest) WaitForNodesReady(numberOfNodes int) error {
 	}
 	b := backoff.NewConstant(backoff.LongMaxWait, backoff.LongMaxInterval)
 	n := func(err error, delay time.Duration) {
-		g.logger.Log("level", "debug", "message", err.Error())
+		g.logger.LogCtx(ctx, "level", "debug", "message", err.Error())
 	}
 
 	err := backoff.RetryNotify(o, b, n)
@@ -265,6 +266,6 @@ func (g *Guest) WaitForNodesReady(numberOfNodes int) error {
 		return microerror.Mask(err)
 	}
 
-	g.logger.Log("level", "debug", "message", fmt.Sprintf("waited for %d k8s nodes to be in %#q state", numberOfNodes, v1.NodeReady))
+	g.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for %d k8s nodes to be in %#q state", numberOfNodes, v1.NodeReady))
 	return nil
 }

--- a/pkg/framework/guest.go
+++ b/pkg/framework/guest.go
@@ -247,7 +247,7 @@ func (g *Guest) WaitForNodesReady(ctx context.Context, expectedNodes int) error 
 			}
 		}
 
-		if nodesReady < expectedNodes {
+		if nodesReady != expectedNodes {
 			return microerror.Maskf(waitError, "found %d/%d k8s nodes in %#q state but %d are expected", nodesReady, len(nodes.Items), v1.NodeReady, expectedNodes)
 		}
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4692

Fixes an issue where the wait for nodes ready counting was not accurate.
Also:
- rename function to `WaitForNodesReady`
- add context argument

CircleCI tests:
- https://circleci.com/workflow-run/16dd07c7-b43b-464d-b266-94be648665ef
- https://circleci.com/workflow-run/559674de-6990-4c48-8787-b9fca2f0739c
- https://circleci.com/workflow-run/d616218f-6a60-4a15-90b1-22f24ffe02ce

Note: draining test is failing, but this is inherent to the draining test itself and not related to the `worker not found issue`.