### PR TITLE
cmd: remove building local image before running tests

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/e2e-harness/pkg/compiler"
 	"github.com/giantswarm/e2e-harness/pkg/docker"
 	"github.com/giantswarm/e2e-harness/pkg/harness"
-	"github.com/giantswarm/e2e-harness/pkg/minikube"
 	"github.com/giantswarm/e2e-harness/pkg/patterns"
 	"github.com/giantswarm/e2e-harness/pkg/project"
 	"github.com/giantswarm/e2e-harness/pkg/tasks"
@@ -125,16 +124,8 @@ func runTest(ctx context.Context, cmd *cobra.Command, args []string) error {
 	bundle := []tasks.Task{
 		pullGoDockerImageTask,
 		comp.CompileTests,
+		p.Test,
 	}
-
-	if !cfg.RemoteCluster {
-		// build images for minikube
-		m := minikube.New(logger, d, projectTag)
-
-		bundle = append(bundle, comp.CompileMain, m.BuildImages)
-	}
-
-	bundle = append(bundle, p.Test)
 
 	return tasks.Run(ctx, bundle)
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5278.

We discovered that during testing release-operator. Now during e2e tests
we use local image with binary built by e2e-harness instead the one from
quay. This PR fixes that. This should also make significant time savings
because we don't compile the binary.