### PR TITLE
update golang to 1.12.6

### DIFF
--- a/internal/golang/key.go
+++ b/internal/golang/key.go
@@ -1,7 +1,7 @@
 package golang
 
 const (
-	dockerImage = "quay.io/giantswarm/golang:1.11.1"
+	dockerImage = "quay.io/giantswarm/golang:1.12.6"
 	goOS        = "linux"
 	goArch      = "amd64"
 	cgoEnabled  = "0"


### PR DESCRIPTION
Attempt at fixing failing CircleCI builds

```
filesystem layer verification failed for digest sha256:1bc310ac474b880a5e4aeec02e6423d1304d137f1a8990074cb3ac6386a0b654
{"caller":"github.com/giantswarm/e2e-harness/vendor/github.com/giantswarm/backoff/notifier.go:13","level":"warning","message":"retrying backoff in '552.330144ms' due to error","stack":"[{/go/src/github.com/giantswarm/e2e-harness/pkg/tasks/retry_task.go:28: } {/go/src/github.com/giantswarm/e2e-harness/internal/golang/pull_docker_image.go:17: } {/go/src/github.com/giantswarm/e2e-harness/internal/docker/pull.go:19: } {/go/src/github.com/giantswarm/e2e-harness/internal/exec/exec.go:21: } {exit status 1}]","time":"2019-07-11T09:51:28.547464+00:00"}
1.11.1: Pulling from giantswarm/golang
```
https://circleci.com/gh/giantswarm/cert-exporter/193
https://gigantic.slack.com/archives/C3C7ZQXC1/p1562829091029100

Since we currently manage only golang 1.11.6 and 1.12.6 in [retagger](https://github.com/giantswarm/retagger/blob/495122109f849afdf7fd9c11581552034844d79c/images.yaml#L137-L142), I choosed to bump to the later in this PR.

