### PR TITLE
Update Go to 1.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk -Uuv add --update --no-cache \
       less=530-r0 \
       libffi-dev=3.2.1-r4 \
       openssh-client=7.7_p1-r4 \
-      openssl=1.0.2r-r0 \
+      openssl=1.0.2t-r0 \
       sudo=1.8.23-r2 \
       iptables=1.6.2-r0
 

--- a/internal/golang/key.go
+++ b/internal/golang/key.go
@@ -1,7 +1,7 @@
 package golang
 
 const (
-	dockerImage = "quay.io/giantswarm/golang:1.12.6"
+	dockerImage = "quay.io/giantswarm/golang:1.13.0"
 	goOS        = "linux"
 	goArch      = "amd64"
 	cgoEnabled  = "0"


### PR DESCRIPTION
Syncs with Go version in architect (see https://github.com/giantswarm/architect/pull/334).