### PR TITLE
Use micrologger v0.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@ RUN chown -R e2e-harness:e2e-harness ${WORKDIR} ${HOME}
 RUN apk -Uuv add --update --no-cache \
       bash=4.4.19-r1 \
       build-base=0.5-r1 \
-      git=2.18.1-r0 \
+      git=2.18.2-r0 \
       jq=1.6_rc1-r1 \
       less=530-r0 \
       libffi-dev=3.2.1-r4 \
       openssh-client=7.7_p1-r4 \
-      openssl=1.0.2t-r0 \
-      sudo=1.8.23-r2 \
+      openssl=1.0.2u-r0 \
+      sudo=1.8.23-r4 \
       iptables=1.6.2-r0
 
 ENV KUBECTL_VERSION=v1.16.3

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -220,11 +220,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9df3a29f6c60e6a436e53384d94d15fec3187b9bf9463aaa1a7d9d61931e51ba"
+  digest = "1:0b6e8390c8a20214832d477682602576c3d3f9af28651e77694d6156a7a09023"
   name = "github.com/giantswarm/apprclient"
   packages = ["."]
   pruneopts = "UT"
-  revision = "955b7e89e6e212610b2f233082fbe76636c8acf1"
+  revision = "d6357fcac73036aa3d0e6267edffc34bd40c7d51"
 
 [[projects]]
   branch = "master"
@@ -244,11 +244,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f3e73f108ebb31c9a021261f9aaf8c8c430dfce7716b26253065afdb18be774a"
+  digest = "1:d3c4629c2a900df5b1d9ca30b4fb509ef35f796be645fa5df929110710c0ee2e"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d3c47349776d30db46c3e200ee94d16aeb22aa0b"
+  revision = "26da7a78a1801bb05f2b47b4b1e833ca22bb423a"
 
 [[projects]]
   branch = "master"
@@ -267,8 +267,7 @@
   revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c313924ca7110c452a83502384552f4dd2ed25dd0f3ab8aa8a34707315243561"
+  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -276,15 +275,16 @@
     "microloggertest",
   ]
   pruneopts = "UT"
-  revision = "d866337f739365a54de5924b8a7b29df17693ef8"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:90fda7152f6ded9c45d67bee5f23f2d8f148eb15672f30030c095e08eccf02b0"
+  digest = "1:e6227e79e59fea0321b7206823740cdebfd813ad52b5afec79c836385f91480a"
   name = "github.com/giantswarm/versionbundle"
   packages = ["."]
   pruneopts = "UT"
-  revision = "be95231628aed039183214a0e337bfe621e3072a"
+  revision = "c6a9f18d7762cb6bcc244b6d78adfa1d1eb179f0"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@ required = [
 
 [[constraint]]
   name = "github.com/giantswarm/micrologger"
-  branch = "master"
+  version = "v0.1.0"
 
 [[constraint]]
   name = "github.com/giantswarm/versionbundle"

--- a/vendor/github.com/giantswarm/apprclient/Gopkg.lock
+++ b/vendor/github.com/giantswarm/apprclient/Gopkg.lock
@@ -75,14 +75,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ca9ad5887021e13fca3a1aa33a58668a0061b3a03bd7dfc2d36c38dedf56f572"
+  digest = "1:a6fdcbdc9a98d2174017f2a00e32e835c3ee6739e15a476285e981ab6d7e4627"
   name = "github.com/giantswarm/k8sclient"
   packages = [
     ".",
     "k8scrdclient",
   ]
   pruneopts = "UT"
-  revision = "6cb127468cd6b30eaf8030b875f796e34b481938"
+  revision = "78de8231ec254eba941e9999c2b13581b2d2103b"
 
 [[projects]]
   branch = "master"
@@ -101,8 +101,7 @@
   revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c313924ca7110c452a83502384552f4dd2ed25dd0f3ab8aa8a34707315243561"
+  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -110,7 +109,8 @@
     "microloggertest",
   ]
   pruneopts = "UT"
-  revision = "d866337f739365a54de5924b8a7b29df17693ef8"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"

--- a/vendor/github.com/giantswarm/apprclient/Gopkg.toml
+++ b/vendor/github.com/giantswarm/apprclient/Gopkg.toml
@@ -43,7 +43,7 @@
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.1.0"
   name = "github.com/giantswarm/micrologger"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/helmclient/Gopkg.lock
+++ b/vendor/github.com/giantswarm/helmclient/Gopkg.lock
@@ -263,14 +263,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ca9ad5887021e13fca3a1aa33a58668a0061b3a03bd7dfc2d36c38dedf56f572"
+  digest = "1:a6fdcbdc9a98d2174017f2a00e32e835c3ee6739e15a476285e981ab6d7e4627"
   name = "github.com/giantswarm/k8sclient"
   packages = [
     ".",
     "k8scrdclient",
   ]
   pruneopts = "UT"
-  revision = "6cb127468cd6b30eaf8030b875f796e34b481938"
+  revision = "78de8231ec254eba941e9999c2b13581b2d2103b"
 
 [[projects]]
   branch = "master"
@@ -289,8 +289,7 @@
   revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c313924ca7110c452a83502384552f4dd2ed25dd0f3ab8aa8a34707315243561"
+  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
@@ -298,7 +297,8 @@
     "microloggertest",
   ]
   pruneopts = "UT"
-  revision = "d866337f739365a54de5924b8a7b29df17693ef8"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"
@@ -1584,6 +1584,7 @@
     "k8s.io/api/networking/v1",
     "k8s.io/api/policy/v1beta1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/api/scheduling/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/util/intstr",

--- a/vendor/github.com/giantswarm/helmclient/Gopkg.toml
+++ b/vendor/github.com/giantswarm/helmclient/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
 
 [[constraint]]
   name = "github.com/giantswarm/micrologger"
-  branch = "master"
+  version = "v0.1.0"
 
 [[constraint]]
   name = "github.com/google/go-cmp"

--- a/vendor/github.com/giantswarm/helmclient/ensure_tiller_installed.go
+++ b/vendor/github.com/giantswarm/helmclient/ensure_tiller_installed.go
@@ -12,6 +12,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -339,6 +340,36 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 	}
 
+	// Create the priority class for the tiller deployment.
+	{
+		priorityClassName := "giantswarm-critical"
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating priorityclass %#q", priorityClassName))
+
+		pc := &schedulingv1.PriorityClass{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "scheduling.k8s.io/v1",
+				Kind:       "PriorityClass",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: priorityClassName,
+			},
+			Value:         1000000000,
+			GlobalDefault: false,
+			Description:   "This priority class is used by giantswarm kubernetes components.",
+		}
+
+		_, err := c.k8sClient.SchedulingV1().PriorityClasses().Create(pc)
+		if errors.IsAlreadyExists(err) {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("priorityclass %#q already exists", priorityClassName))
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created priorityclass %#q", priorityClassName))
+		}
+	}
+
 	var err error
 	var installTiller bool
 	var pod *corev1.Pod
@@ -395,6 +426,10 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 			return microerror.Mask(err)
 		}
 	} else if !installTiller && upgradeTiller {
+		if !c.tillerUpgradeEnabled {
+			c.logger.LogCtx(ctx, "level", "debug", "message", "found an out-dated tiller but upgrades not enabled")
+			return nil
+		}
 		err = c.upgradeTiller(ctx, i)
 		if err != nil {
 			return microerror.Mask(err)
@@ -463,7 +498,7 @@ func (c *Client) installTiller(ctx context.Context, installerOptions *installer.
 
 		return nil
 	}
-	b := backoff.NewExponential(2*time.Minute, 5*time.Second)
+	b := backoff.NewExponential(c.ensureTillerInstalledMaxWait, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, context.Background())
 
 	err := backoff.RetryNotify(o, b, n)
@@ -487,7 +522,7 @@ func (c *Client) upgradeTiller(ctx context.Context, installerOptions *installer.
 
 		return nil
 	}
-	b := backoff.NewExponential(2*time.Minute, 5*time.Second)
+	b := backoff.NewExponential(c.ensureTillerInstalledMaxWait, 5*time.Second)
 	n := backoff.NewNotifier(c.logger, context.Background())
 
 	err := backoff.RetryNotify(o, b, n)

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -1,6 +1,7 @@
 package helmclient
 
 import (
+	"net"
 	"regexp"
 	"strings"
 
@@ -27,6 +28,32 @@ func IsCannotReuseRelease(err error) bool {
 		return true
 	}
 	if c == cannotReuseReleaseError {
+		return true
+	}
+
+	return false
+}
+
+var (
+	emptyChartTemplatesRegexp = regexp.MustCompile(`release \S+ failed: no objects visited`)
+)
+
+var emptyChartTemplatesError = &microerror.Error{
+	Kind: "emptyChartTemplatesError",
+}
+
+// IsEmptyChartTemplates asserts emptyChartTemplatesError.
+func IsEmptyChartTemplates(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == emptyChartTemplatesError {
+		return true
+	}
+	if emptyChartTemplatesRegexp.MatchString(c.Error()) {
 		return true
 	}
 
@@ -95,6 +122,39 @@ func IsPullChartFailedError(err error) bool {
 	return microerror.Cause(err) == pullChartFailedError
 }
 
+var pullChartNotFoundError = &microerror.Error{
+	Kind: "pullChartNotFoundError",
+}
+
+// IsPullChartNotFound asserts pullChartNotFoundError.
+func IsPullChartNotFound(err error) bool {
+	return microerror.Cause(err) == pullChartNotFoundError
+}
+
+var pullChartTimeoutError = &microerror.Error{
+	Kind: "pullChartTimeoutError",
+}
+
+// IsPullChartTimeout asserts pullChartTimeoutError.
+func IsPullChartTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == pullChartTimeoutError {
+		return true
+	}
+
+	netErr, ok := err.(net.Error)
+	if !ok {
+		return false
+	}
+
+	return netErr.Timeout()
+}
+
 var (
 	releaseAlreadyExistsRegexp = regexp.MustCompile(`release named \S+ already exists`)
 )
@@ -115,6 +175,62 @@ func IsReleaseAlreadyExists(err error) bool {
 		return true
 	}
 	if releaseAlreadyExistsRegexp.MatchString(c.Error()) {
+		return true
+	}
+
+	return false
+}
+
+const (
+	releaseNameInvalidErrorPrefix = "invalid release name"
+	releaseNameInvalidErrorSuffix = "and the length must not be longer than 53"
+)
+
+var releaseNameInvalidError = &microerror.Error{
+	Kind: "releaseNameInvalidError",
+}
+
+// IsReleaseNameInvalid asserts releaseNameInvalidError.
+func IsReleaseNameInvalid(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasPrefix(c.Error(), releaseNameInvalidErrorPrefix) {
+		return true
+	}
+	if strings.HasSuffix(c.Error(), releaseNameInvalidErrorSuffix) {
+		return true
+	}
+	if c == releaseNameInvalidError {
+		return true
+	}
+
+	return false
+}
+
+const (
+	releaseNotDeployedErrorSuffix = "has no deployed releases"
+)
+
+var releaseNotDeployedError = &microerror.Error{
+	Kind: "releaseNotDeployedError",
+}
+
+// IsReleaseNotDeployed asserts releaseNotDeployedError.
+func IsReleaseNotDeployed(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if strings.HasSuffix(c.Error(), releaseNotDeployedErrorSuffix) {
+		return true
+	}
+	if c == releaseNotDeployedError {
 		return true
 	}
 
@@ -220,6 +336,15 @@ var tillerInvalidVersionError = &microerror.Error{
 // IsTillerInvalidVersion asserts tillerInvalidVersionError.
 func IsTillerInvalidVersion(err error) bool {
 	return microerror.Cause(err) == tillerInvalidVersionError
+}
+
+var tillerOutdatedError = &microerror.Error{
+	Kind: "tillerOutdatedError",
+}
+
+// IsTillerOutdated asserts tillerOutdatedError.
+func IsTillerOutdated(err error) bool {
+	return microerror.Cause(err) == tillerOutdatedError
 }
 
 var tooManyResultsError = &microerror.Error{

--- a/vendor/github.com/giantswarm/helmclient/helmclient.go
+++ b/vendor/github.com/giantswarm/helmclient/helmclient.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/k8sportforward"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -57,6 +58,7 @@ type Config struct {
 	TillerImageName              string
 	TillerImageRegistry          string
 	TillerNamespace              string
+	TillerUpgradeEnabled         bool
 }
 
 // Client knows how to talk with a Helm Tiller server.
@@ -71,6 +73,7 @@ type Client struct {
 	restConfig                   *rest.Config
 	tillerImage                  string
 	tillerNamespace              string
+	tillerUpgradeEnabled         bool
 }
 
 // New creates a new configured Helm client.
@@ -120,6 +123,7 @@ func New(config Config) (*Client, error) {
 		restConfig:                   config.RestConfig,
 		tillerImage:                  tillerImage,
 		tillerNamespace:              config.TillerNamespace,
+		tillerUpgradeEnabled:         config.TillerUpgradeEnabled,
 	}
 
 	return c, nil
@@ -197,6 +201,14 @@ func (c *Client) getReleaseContent(ctx context.Context, releaseName string) (*Re
 		o := func() error {
 			t, err := c.newTunnel()
 			if IsTillerNotFound(err) {
+				return backoff.Permanent(microerror.Mask(err))
+			} else if IsTillerOutdated(err) {
+				return backoff.Permanent(microerror.Mask(err))
+			} else if IsEmptyChartTemplates(err) {
+				return backoff.Permanent(microerror.Mask(err))
+			} else if IsReleaseNameInvalid(err) {
+				return backoff.Permanent(microerror.Mask(err))
+			} else if tenant.IsAPINotAvailable(err) {
 				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)
@@ -344,6 +356,8 @@ func (c *Client) installReleaseFromTarball(ctx context.Context, path, ns string,
 		if IsCannotReuseRelease(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsReleaseAlreadyExists(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsEmptyChartTemplates(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsTarballNotFound(err) {
 			return backoff.Permanent(microerror.Mask(err))
@@ -597,7 +611,11 @@ func (c *Client) updateReleaseFromTarball(ctx context.Context, releaseName, path
 		defer c.closeTunnel(ctx, t)
 
 		release, err := c.newHelmClientFromTunnel(t).UpdateRelease(releaseName, path, options...)
-		if IsReleaseNotFound(err) {
+		if IsReleaseNotDeployed(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsReleaseNotFound(err) {
+			return backoff.Permanent(microerror.Mask(err))
+		} else if IsEmptyChartTemplates(err) {
 			return backoff.Permanent(microerror.Mask(err))
 		} else if IsYamlConversionFailed(err) {
 			return backoff.Permanent(microerror.Mask(err))
@@ -681,7 +699,11 @@ func (c *Client) newTunnel() (*k8sportforward.Tunnel, error) {
 	// Do not create a tunnel if tiller is outdated.
 	err = validateTillerVersion(pod, c.tillerImage)
 	if err != nil {
-		return nil, microerror.Mask(err)
+		if IsTillerInvalidVersion(err) && !c.tillerUpgradeEnabled {
+			return nil, microerror.Maskf(tillerOutdatedError, "found an out-dated tiller but upgrades not enabled")
+		} else {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	var forwarder *k8sportforward.Forwarder

--- a/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] 2020-02-13
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/micrologger/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/versionbundle/Gopkg.lock
+++ b/vendor/github.com/giantswarm/versionbundle/Gopkg.lock
@@ -2,79 +2,102 @@
 
 
 [[projects]]
+  digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
   name = "github.com/coreos/go-semver"
   packages = ["semver"]
+  pruneopts = "UT"
   revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d80347cb345b2986422040821735ae0efba8b8093b765b146b90796d926b85b4"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
-  revision = "325932fa68e70dd4464598f11e2f710ac1aaec46"
+  pruneopts = "UT"
+  revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
 
 [[projects]]
-  branch = "master"
+  digest = "1:c497795cf3848ef5a655d53f24dfc670c72f9b2fc41eeda495d66542ae6bd017"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
     "loggermeta",
-    "microloggertest"
+    "microloggertest",
   ]
-  revision = "2aaea11da0707ebb7f9fbabb07028a37b00efc16"
+  pruneopts = "UT"
+  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
+  version = "v0.1.0"
 
 [[projects]]
+  digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"
   name = "github.com/go-kit/kit"
   packages = ["log"]
+  pruneopts = "UT"
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
 [[projects]]
+  digest = "1:4062bc6de62d73e2be342243cf138cf499b34d558876db8d9430e2149388a4d8"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
-  revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
-  version = "v0.3.0"
+  pruneopts = "UT"
+  revision = "07c9b44f60d7ffdfb7d8efe1ad539965737836dc"
+  version = "v0.4.0"
 
 [[projects]]
+  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
-  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
-  version = "v1.7.0"
+  pruneopts = "UT"
+  revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:926b6084b81f49359f67e48ef8b74f33ea8509afe8410d3b34789eaea02da898"
   name = "github.com/juju/errgo"
   packages = ["."]
+  pruneopts = "UT"
   revision = "08cceb5d0b5331634b9826762a8fd53b29b86ad8"
 
 [[projects]]
   branch = "master"
+  digest = "1:a64e323dc06b73892e5bb5d040ced475c4645d456038333883f58934abbf6f72"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:64bf36b06fd69367f28726281e3c9d9a541eae5b89225dfd282c18f03ec9da19"
   name = "golang.org/x/net"
   packages = [
-    "context",
     "idna",
-    "publicsuffix"
+    "publicsuffix",
   ]
-  revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
+  pruneopts = "UT"
+  revision = "c0dbc17a35534bf2e581d7a942408dc936316da4"
 
 [[projects]]
   branch = "master"
+  digest = "1:b521f10a2d8fa85c04a8ef4e62f2d1e14d303599a55d64dabf9f5a02f84d35eb"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+  pruneopts = "UT"
+  revision = "cd5d95a43a6e21273425c7ae415d3df9ea832eeb"
 
 [[projects]]
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -84,20 +107,30 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  pruneopts = "UT"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
+  digest = "1:41206f4d0410803e64cfb203f665330c3183988408cb532b56305a816a87bd99"
   name = "gopkg.in/resty.v1"
   packages = ["."]
+  pruneopts = "UT"
   revision = "fa5875c0caa5c260ab78acec5a244215a730247f"
   version = "v1.12.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e646c3794bf400a9cac7d0f005eaffea1fd6dbc68efb7d0aeba513e23258a0be"
+  input-imports = [
+    "github.com/coreos/go-semver/semver",
+    "github.com/giantswarm/microerror",
+    "github.com/giantswarm/micrologger",
+    "github.com/giantswarm/micrologger/microloggertest",
+    "golang.org/x/sync/errgroup",
+    "gopkg.in/resty.v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/giantswarm/versionbundle/Gopkg.toml
+++ b/vendor/github.com/giantswarm/versionbundle/Gopkg.toml
@@ -25,6 +25,7 @@
 #   unused-packages = true
 
 
+
 [[constraint]]
   name = "github.com/coreos/go-semver"
   version = "0.2.0"
@@ -34,7 +35,7 @@
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.1.0"
   name = "github.com/giantswarm/micrologger"
 
 [[constraint]]
@@ -43,11 +44,9 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/kylelemons/godebug"
-
-[[constraint]]
-  branch = "master"
   name = "golang.org/x/sync"
+
+
 
 [prune]
   go-tests = true

--- a/vendor/github.com/giantswarm/versionbundle/app.go
+++ b/vendor/github.com/giantswarm/versionbundle/app.go
@@ -1,0 +1,17 @@
+package versionbundle
+
+type App struct {
+	App              string `yaml:"app"`
+	ComponentVersion string `yaml:"componentVersion"`
+	Version          string `yaml:"version"`
+}
+
+func (a App) AppID() string {
+	return a.App + ":" + a.Version
+}
+
+func CopyApps(apps []App) []App {
+	appList := make([]App, len(apps))
+	copy(appList, apps)
+	return appList
+}

--- a/vendor/github.com/giantswarm/versionbundle/app_changelog.go
+++ b/vendor/github.com/giantswarm/versionbundle/app_changelog.go
@@ -1,0 +1,5 @@
+package versionbundle
+
+type AppsChangelogs map[string][]Changelog
+
+type ReleasesChangelogs map[string]AppsChangelogs

--- a/vendor/github.com/giantswarm/versionbundle/changelog.go
+++ b/vendor/github.com/giantswarm/versionbundle/changelog.go
@@ -2,6 +2,7 @@ package versionbundle
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 )
@@ -9,23 +10,17 @@ import (
 type kind string
 
 const (
-	// KindAdded being used in a changelog describes an authority's component got
-	// added.
+	// KindAdded is used in changelogs for new features.
 	KindAdded kind = "added"
-	// KindChanged being used in a changelog describes an authority's component got
-	// changed.
+	// KindChanged is used in changelogs for changes in existing functionality.
 	KindChanged kind = "changed"
-	// KindDeprecated being used in a changelog describes an authority's component got
-	// deprecated.
+	// KindDeprecated is used in a changelogs for soon-to-be removed features.
 	KindDeprecated kind = "deprecated"
-	// KindFixed being used in a changelog describes an authority's component got
-	// fixed.
+	// KindFixed is used in changelogs for any bug fixes.
 	KindFixed kind = "fixed"
-	// KindRemoved being used in a changelog describes an authority's component got
-	// removed.
+	// KindRemoved is used in changelogs for now removed features.
 	KindRemoved kind = "removed"
-	// KindSecurity being used in a changelog describes an authority's component got
-	// adapted for security reasons.
+	// KindSecurity is used in chnagelogs in case of vulnerabilities.
 	KindSecurity kind = "security"
 )
 
@@ -48,7 +43,9 @@ type Changelog struct {
 	// version bundles the given component must exist, either within the same
 	// authority or within another authority within the infrastructure. That is,
 	// Aggregate must know about it to be able to properly merge version bundles.
-	Component string `json:"component" yaml:"component"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
+	// ComponentVersion is the upstream version of the exposed component.
+	ComponentVersion string `json:"componentVersion,omitempty" yaml:"componentVersion,omitempty"`
 	// Description is some text describing the changelog entry. This information
 	// is intended to be useful for humans.
 	Description string `json:"description" yaml:"description"`
@@ -58,6 +55,8 @@ type Changelog struct {
 	// URLs is a list of links which contain additional information to the
 	// changelog entry such as upstream changelogs or pull requests.
 	URLs []string `json:"urls" yaml:"urls"`
+	// Version is the Giant Swarm version of the component.
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 func (c Changelog) String() string {
@@ -103,4 +102,14 @@ func CopyChangelogs(changelogs []Changelog) []Changelog {
 	}
 
 	return copy
+}
+
+func NewKind(kindType string) (kind, error) {
+	converted := kind(strings.ToLower(kindType))
+	for _, k := range validKinds {
+		if converted == k {
+			return converted, nil
+		}
+	}
+	return kind(""), microerror.Maskf(executionFailedError, "kind must be one of %#v", validKinds)
 }

--- a/vendor/github.com/giantswarm/versionbundle/collector.go
+++ b/vendor/github.com/giantswarm/versionbundle/collector.go
@@ -77,7 +77,9 @@ func (c *Collector) Collect(ctx context.Context, endpoints []*url.URL) error {
 
 				res, err := c.restClient.NewRequest().Get(e.String())
 				if err != nil {
-					return microerror.Mask(err)
+					c.logger.Log("endpoint", e.String(), "level", "error", "message", "requesting version bundles from endpoint failed", "stack", microerror.Stack(err))
+					c.logger.Log("endpoint", e.String(), "level", "debug", "message", "some releases may not be computed correctly")
+					return nil
 				}
 
 				c.logger.Log("endpoint", e.String(), "level", "debug", "message", "requested version bundles from endpoint")

--- a/vendor/github.com/giantswarm/versionbundle/index_release.go
+++ b/vendor/github.com/giantswarm/versionbundle/index_release.go
@@ -12,10 +12,9 @@ import (
 	"github.com/giantswarm/micrologger"
 )
 
-const indexReleaseTimestampFormat = "2006-01-02T15:04:05.00Z"
-
 type IndexRelease struct {
 	Active      bool        `yaml:"active"`
+	Apps        []App       `yaml:"apps"`
 	Authorities []Authority `yaml:"authorities"`
 	Date        time.Time   `yaml:"date"`
 	Version     string      `yaml:"version"`
@@ -56,6 +55,7 @@ func buildReleases(logger micrologger.Logger, indexReleases []IndexRelease, bund
 
 		rc := ReleaseConfig{
 			Active:  ir.Active,
+			Apps:    ir.Apps,
 			Bundles: bundles,
 			Date:    ir.Date,
 			Version: ir.Version,
@@ -230,15 +230,18 @@ func validateUniqueReleases(indexReleases []IndexRelease) error {
 		releaseVersions[release.Version] = release.Version
 
 		// Verify release version contents
-		authorities := make([]string, 0, len(release.Authorities))
+		appsAndAuthorities := make([]string, 0, len(release.Apps)+len(release.Authorities))
+		for _, a := range release.Apps {
+			appsAndAuthorities = append(appsAndAuthorities, a.AppID())
+		}
 		for _, a := range release.Authorities {
-			authorities = append(authorities, a.BundleID())
+			appsAndAuthorities = append(appsAndAuthorities, a.BundleID())
 		}
 
-		sort.Strings(authorities)
+		sort.Strings(appsAndAuthorities)
 
 		sha256Hash.Reset()
-		sha256Hash.Write([]byte(strings.Join(authorities, ",")))
+		sha256Hash.Write([]byte(strings.Join(appsAndAuthorities, ",")))
 
 		hexHash := hex.EncodeToString(sha256Hash.Sum(nil))
 		otherVer, exists = releaseChecksums[hexHash]

--- a/vendor/github.com/giantswarm/versionbundle/release.go
+++ b/vendor/github.com/giantswarm/versionbundle/release.go
@@ -12,12 +12,14 @@ const releaseTimestampFormat = "2006-01-02T15:04:05.000000Z"
 
 type ReleaseConfig struct {
 	Active  bool
+	Apps    []App
 	Bundles []Bundle
 	Date    time.Time
 	Version string
 }
 
 type Release struct {
+	apps       []App
 	bundles    []Bundle
 	changelogs []Changelog
 	components []Component
@@ -51,6 +53,7 @@ func NewRelease(config ReleaseConfig) (Release, error) {
 
 	r := Release{
 		active:     config.Active,
+		apps:       config.Apps,
 		bundles:    config.Bundles,
 		changelogs: changelogs,
 		components: components,
@@ -63,6 +66,10 @@ func NewRelease(config ReleaseConfig) (Release, error) {
 
 func (r Release) Active() bool {
 	return r.active
+}
+
+func (r Release) Apps() []App {
+	return CopyApps(r.apps)
 }
 
 func (r Release) Bundles() []Bundle {


### PR DESCRIPTION
We need to pin the micrologger dependency to the v0.1.0 version which is the one using dep instead of newer versions that use go modules.

