### PR TITLE
Add version to project.go to trick release workflow

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -152,6 +152,7 @@ func (p *Project) CommonTearDownSteps(ctx context.Context) error {
 }
 
 func (p *Project) Test(ctx context.Context) error {
+	p.logger.Log("level", "debug", "message", fmt.Sprintf("e2e-harness version %q", version))
 	p.logger.Log("level", "info", "message", "started tests")
 
 	// --test-dir is mounted in /e2e in the test container, and the binary with

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	DefaultDirectory = "integration"
+	version          = "0.2.0"
 )
 
 type E2e struct {


### PR DESCRIPTION
I think this should be more or less an exception among our projects so
I don't think it's worth it to start changing the workflow but instead just
adapt this library to match expectations.
